### PR TITLE
Multiple JOINS

### DIFF
--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -375,18 +375,18 @@ public struct Select: Query {
     private func on(clause: Any) -> Select {
         var new = self
         
-        guard self.joins.count > 0 else {
+        guard new.joins.count > 0 else {
             new.syntaxError += "On clause set for statement that is not join. "
             return new
         }
         
-        if self.joins.last?.on != nil {
+        if new.joins.last?.on != nil {
             new.syntaxError += "Multiple on clauses for a single join."
-        } else if self.joins.last?.using != nil {
+        } else if new.joins.last?.using != nil {
             new.syntaxError += "An on clause is not allowed with a using clause for a single join."
         }
         else {
-            new.joins[self.joins.count - 1].on = clause
+            new.joins[new.joins.count - 1].on = clause
         }
         return new
     }
@@ -399,18 +399,18 @@ public struct Select: Query {
     public func using(_ columns: Column...) -> Select {
         var new = self
         
-        guard self.joins.count > 0 else {
+        guard new.joins.count > 0 else {
             new.syntaxError += "Using clause set for statement that is not join. "
             return new
         }
         
-        if self.joins.last?.using != nil {
+        if new.joins.last?.using != nil {
             new.syntaxError += "Multiple using clauses for a single join."
-        } else if self.joins.last?.on != nil {
+        } else if new.joins.last?.on != nil {
             new.syntaxError += "A using clause is not allowed with an on clause for single join."
         }
         else {
-            new.joins[self.joins.count - 1].using = columns
+            new.joins[new.joins.count - 1].using = columns
         }
         return new
     }

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -58,18 +58,12 @@ public struct Select: Query {
     
     /// The SQL UNION clauses.
     public private (set) var unions: [Union]?
-
-    /// The SQL JOIN clause.
-    public private (set) var join: Join?
-
-    /// The SQL ON clause containing the filter for the rows to select in a JOIN query.
-    public private (set) var onClause: Filter?
-
-    /// A String containg the raw SQL ON clause to filter the rows to select in a JOIN query.
-    public private (set) var rawOnClause: String?
+    
+    /// The SQL JOIN, ON and USING clauses.
+    /// ON clause can be represented as `Filter` or raw SQL.
+    public private (set) var joins = [(join: Join, on: Any?, using: [Column]?)]()
 
     /// The SQL USING clause: an array of `Column` elements that have to match in a JOIN query.
-    public private (set) var using: [Column]?
 
     private var syntaxError = ""
 
@@ -116,14 +110,6 @@ public struct Select: Query {
     /// - Throws: QueryError.syntaxError if query build fails.
     public func build(queryBuilder: QueryBuilder) throws -> String {
         var syntaxError = self.syntaxError
-        if join == nil {
-            if onClause != nil || rawOnClause != nil {
-                syntaxError += "On clause set for statement that is not join. "
-            }
-            if using != nil {
-                syntaxError += "On clause set for statement that is not join. "
-            }
-        }
         
         if groupBy == nil && (havingClause != nil || rawHavingClause != nil) {
             syntaxError += "Having clause is not allowed without a group by clause. "
@@ -148,15 +134,21 @@ public struct Select: Query {
         result += " FROM "
         result += try "\(tables.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", "))"
         
-        if let join = join {
-            result += try join.build(queryBuilder: queryBuilder)
-        }
-        
-        if let onClause = onClause {
-            result += try " ON " + onClause.build(queryBuilder: queryBuilder)
-        }
-        else if let using = using {
-            result += " USING (" + using.map { $0.name }.joined(separator: ", ") + ")"
+        for item in joins {
+            result += try item.join.build(queryBuilder: queryBuilder)
+
+            switch item.on {
+            case let on as Filter:
+                result += try " ON " + on.build(queryBuilder: queryBuilder)
+            case let on as String:
+                result += " ON \(on)"
+            default:
+                break
+            }
+            
+            if let using = item.using {
+                result += " USING (" + using.map { $0.name }.joined(separator: ", ") + ")"
+            }
         }
         
         if let whereClause = whereClause {
@@ -369,17 +361,7 @@ public struct Select: Query {
     /// - Parameter conditions: The `Filter` to apply.
     /// - Returns: A new instance of Select with the ON clause.
     public func on(_ conditions: Filter) -> Select {
-        var new = self
-        if onClause != nil || rawOnClause != nil {
-            new.syntaxError += "Multiple on clauses. "
-        }
-        else if using != nil {
-            new.syntaxError += "An on clause is not allowed with a using clause. "
-        }
-        else {
-            new.onClause = conditions
-        }
-        return new
+        return self.on(clause: conditions)
     }
     
     /// Add a raw SQL ON clause to the JOIN statement.
@@ -387,15 +369,24 @@ public struct Select: Query {
     /// - Parameter conditions: A String containing the SQL ON clause to apply.
     /// - Returns: A new instance of Select with the ON clause.
     public func on(_ raw: String) -> Select {
+        return self.on(clause: raw)
+    }
+    
+    private func on(clause: Any) -> Select {
         var new = self
-        if onClause != nil || rawOnClause != nil {
-            new.syntaxError += "Multiple on clauses. "
+        
+        guard self.joins.count > 0 else {
+            new.syntaxError += "On clause set for statement that is not join. "
+            return new
         }
-        else if using != nil {
-            new.syntaxError += "An on clause is not allowed with a using clause. "
+        
+        if self.joins.last?.on != nil {
+            new.syntaxError += "Multiple on clauses for a single join."
+        } else if self.joins.last?.using != nil {
+            new.syntaxError += "An on clause is not allowed with a using clause for a single join."
         }
         else {
-            new.rawOnClause = raw
+            new.joins[self.joins.count - 1].on = clause
         }
         return new
     }
@@ -407,14 +398,19 @@ public struct Select: Query {
     /// - Returns: A new instance of Select with the USING clause.
     public func using(_ columns: Column...) -> Select {
         var new = self
-        if using != nil {
-            new.syntaxError += "Multiple using clauses. "
+        
+        guard self.joins.count > 0 else {
+            new.syntaxError += "Using clause set for statement that is not join. "
+            return new
         }
-        else if onClause != nil || rawOnClause != nil {
-            new.syntaxError += "A using clause is not allowed with an on clause. "
+        
+        if self.joins.last?.using != nil {
+            new.syntaxError += "Multiple using clauses for a single join."
+        } else if self.joins.last?.on != nil {
+            new.syntaxError += "A using clause is not allowed with an on clause for single join."
         }
         else {
-            new.using = columns
+            new.joins[self.joins.count - 1].using = columns
         }
         return new
     }
@@ -451,12 +447,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT INNER JOIN.
     public func join(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .join(table)
-        }
+        new.joins.append((.join(table), nil, nil))
         return new
     }
     
@@ -466,12 +457,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT LEFT JOIN.
     public func leftJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .left(table)
-        }
+        new.joins.append((.left(table), nil, nil))
         return new
     }
     
@@ -481,12 +467,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT RIGHT JOIN.
     public func rightJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .right(table)
-        }
+        new.joins.append((.right(table), nil, nil))
         return new
     }
     
@@ -496,12 +477,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT FULL JOIN.
     public func fullJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .full(table)
-        }
+        new.joins.append((.full(table), nil, nil))
         return new
     }
     
@@ -511,12 +487,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT CROSS JOIN.
     public func crossJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .cross(table)
-        }
+        new.joins.append((.cross(table), nil, nil))
         return new
     }
     
@@ -526,12 +497,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT NATURAL JOIN.
     public func naturalJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .natural(table)
-        }
+        new.joins.append((.natural(table), nil, nil))
         return new
     }
 
@@ -541,12 +507,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT NATURAL LEFT JOIN.
     public func naturalLeftJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .naturalLeft(table)
-        }
+        new.joins.append((.naturalLeft(table), nil, nil))
         return new
     }
 
@@ -556,12 +517,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT NATURAL RIGHT JOIN.
     public func naturalRightJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .naturalRight(table)
-        }
+        new.joins.append((.naturalRight(table), nil, nil))
         return new
     }
 
@@ -571,12 +527,7 @@ public struct Select: Query {
     /// - Returns: A new instance of Select corresponding to the SELECT NATURAL FULL JOIN.
     public func naturalFullJoin(_ table: Table) -> Select {
         var new = self
-        if join != nil {
-            new.syntaxError += "Multiple joins. "
-        }
-        else {
-            new.join = .naturalFull(table)
-        }
+        new.joins.append((.naturalFull(table), nil, nil))
         return new
     }
 }

--- a/Tests/SwiftKueryTests/TestJoin.swift
+++ b/Tests/SwiftKueryTests/TestJoin.swift
@@ -60,13 +60,32 @@ class TestJoin: XCTestCase {
         var query = "SELECT * FROM table1Join JOIN table2Join ON table1Join.b = table2Join.b"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
+        s = Select(from: myTable1)
+            .join(myTable2)
+            .on(myTable1.b == myTable2.b)
+            .join(myTable3)
+            .on(myTable1.b == myTable3.b)
+        kuery = connection.descriptionOf(query: s)
+        query = "SELECT * FROM table1Join JOIN table2Join ON table1Join.b = table2Join.b JOIN table3Join ON table1Join.b = table3Join.b"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
         let t1 = myTable1.as("t1")
         let t2 = myTable2.as("t2")
+        let t3 = myTable3.as("t3")
         s = Select(from: t1)
             .join(t2)
             .on(t1.b == t2.b)
         kuery = connection.descriptionOf(query: s)
         query = "SELECT * FROM table1Join AS t1 JOIN table2Join AS t2 ON t1.b = t2.b"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
+        s = Select(from: t1)
+            .join(t2)
+            .on(t1.b == t2.b)
+            .join(t3)
+            .on(t1.b == t3.b)
+        kuery = connection.descriptionOf(query: s)
+        query = "SELECT * FROM table1Join AS t1 JOIN table2Join AS t2 ON t1.b = t2.b JOIN table3Join AS t3 ON t1.b = t3.b"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: myTable1)

--- a/Tests/SwiftKueryTests/TestSyntaxError.swift
+++ b/Tests/SwiftKueryTests/TestSyntaxError.swift
@@ -148,7 +148,7 @@ class TestSyntaxError: XCTestCase {
             XCTFail("No syntax error.")
         }
         catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple where clauses. Multiple limits. A using clause is not allowed with an on clause. On clause set for statement that is not join. ")
+            XCTAssertEqual(error, "Multiple where clauses. Multiple limits. On clause set for statement that is not join. Using clause set for statement that is not join. ")
         }
         catch {
             XCTFail("Other than syntax error.")


### PR DESCRIPTION
Implemented a support for multiple join statements by introducing an array with required info such as `JOIN` type, `ON` clause (which could be a `Filter` or raw SQL) and `USING` clause.  
`.syntaxError` value is almost the same with exception that both `.on` and `.using` methods is checking `JOIN` clause existence when they are used and not on `.build`.

Also added tests to check if `Select` query with multiple joins is correct.

Issue: IBM-Swift/Swift-Kuery#29