### PR TITLE
Simplify the use of clauses that use raw SQL.

### DIFF
--- a/Sources/Delete.swift
+++ b/Sources/Delete.swift
@@ -22,10 +22,8 @@ public struct Delete: Query {
     public let table: Table
 
     /// The SQL WHERE clause containing the filter for rows to delete.
-    public private (set) var whereClause: Filter?
-
-    /// A String containg the raw SQL WHERE clause to filter the rows to delete.
-    public private (set) var rawWhereClause: String?
+    /// Could be represented with the `Filter` clause or a `String` containing raw SQL.
+    public private (set) var whereClause: QueryFilterProtocol?
 
     private var syntaxError = ""
 
@@ -33,7 +31,7 @@ public struct Delete: Query {
     ///
     /// - Parameter from: The table to delete rows from.
     /// - Parameter conditions: An optional where clause to apply.
-    public init(from table: Table, where conditions: Filter?=nil) {
+    public init(from table: Table, where conditions: QueryFilterProtocol?=nil) {
         self.table = table
         self.whereClause = conditions
     }
@@ -51,39 +49,21 @@ public struct Delete: Query {
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }
-        else if let rawWhereClause = rawWhereClause {
-            result += " WHERE " + rawWhereClause
-        }
         result = updateParameterNumbers(query: result, queryBuilder: queryBuilder)
         return result
     }
     
     /// Add an SQL WHERE clause to the delete statement.
     ///
-    /// - Parameter conditions: The SQL WHERE clause to apply.
+    /// - Parameter conditions: The `Filter` clause or a `String` containing SQL WHERE clause to apply.
     /// - Returns: A new instance of Delete.
-    public func `where`(_ conditions: Filter) -> Delete {
+    public func `where`(_ conditions: QueryFilterProtocol) -> Delete {
         var new = self
-        if whereClause != nil || rawWhereClause != nil {
+        if whereClause != nil {
             new.syntaxError += "Multiple where clauses. "
         }
         else {
             new.whereClause = conditions
-        }
-        return new
-    }
-
-    /// Add a raw SQL WHERE clause to the delete statement.
-    ///
-    /// - Parameter conditions: A String containing the SQL WHERE clause to apply.
-    /// - Returns: A new instance of Delete.
-    public func `where`(_ raw: String) -> Delete {
-        var new = self
-        if whereClause != nil || rawWhereClause != nil {
-            new.syntaxError += "Multiple where clauses. "
-        }
-        else {
-            new.rawWhereClause = raw
         }
         return new
     }

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -36,6 +36,8 @@ public struct Filter: ConditionalClause, QueryFilterProtocol {
 
 // MARK: QueryFilterProtocol
 
+/// Defines the protocol which should be used for all filtering clauses.
+/// Represents a filter as String value.
 public protocol QueryFilterProtocol: Buildable {
     
 }

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -17,7 +17,7 @@
 // MARK: Filter
 
 /// A condition used in an SQL WHERE or ON clause.
-public struct Filter: ConditionalClause {
+public struct Filter: ConditionalClause, QueryFilterProtocol {
     public typealias ClauseType = Filter
     public typealias ColumnExpressionType = ScalarColumnExpression
     /// The left hand side of the conditional clause.
@@ -32,6 +32,12 @@ public struct Filter: ConditionalClause {
         self.rhs = rhs
         self.condition = condition
     }
+}
+
+// MARK: QueryFilterProtocol
+
+public protocol QueryFilterProtocol: Buildable {
+    
 }
 
 // MARK Global functions

--- a/Sources/Having.swift
+++ b/Sources/Having.swift
@@ -36,6 +36,8 @@ public struct Having: ConditionalClause, QueryHavingProtocol {
 
 // MARK: QueryHavingProtocol
 
+/// Defines the protocol which should be used for all HAVING clauses.
+/// Represents a HAVING clause as String value.
 public protocol QueryHavingProtocol: Buildable {
     
 }

--- a/Sources/Having.swift
+++ b/Sources/Having.swift
@@ -34,6 +34,12 @@ public struct Having: ConditionalClause {
     }
 }
 
+// MARK: QueryHavingProtocol
+
+public protocol QueryHavingProtocol: Buildable {
+    
+}
+
 // MARK Global functions
 
 /// Create a `Having` clause using the OR operator.

--- a/Sources/Having.swift
+++ b/Sources/Having.swift
@@ -17,7 +17,7 @@
 // MARK: Having
 
 /// An SQL HAVING clause.
-public struct Having: ConditionalClause {
+public struct Having: ConditionalClause, QueryHavingProtocol {
     public typealias ClauseType = Having
     public typealias ColumnExpressionType = AggregateColumnExpression
     /// The left hand side of the conditional clause.

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -317,7 +317,7 @@ public struct Select: Query {
     ///
     /// - Parameter conditions: The `Filter` clause or a `String` containing SQL ON clause to apply.
     /// - Returns: A new instance of Select with the ON clause.
-    private func on(_ conditions: SelectionFilter) -> Select {
+    public func on(_ conditions: SelectionFilter) -> Select {
         var new = self
         
         guard new.joins.count > 0 else {

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -131,13 +131,8 @@ public struct Select: Query {
         for item in joins {
             result += try item.join.build(queryBuilder: queryBuilder)
 
-            switch item.on {
-            case let on as Filter:
+            if let on = item.on {
                 result += try " ON " + on.build(queryBuilder: queryBuilder)
-            case let on as String:
-                result += " ON \(on)"
-            default:
-                break
             }
             
             if let using = item.using {

--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -25,7 +25,7 @@ public struct Select: Query {
     public let tables: [Table]
 
     /// The SQL WHERE clause containing the filter for rows to retrieve.
-    public private (set) var whereClause: SelectionFilter?
+    public private (set) var whereClause: QueryFilterProtocol?
     
     /// A boolean indicating whether the selected values have to be distinct.
     /// If true, corresponds to the SQL SELECT DISTINCT statement.
@@ -48,14 +48,14 @@ public struct Select: Query {
     public private (set) var groupBy: [Column]?
 
     /// The SQL HAVING clause containing the filter for the rows to select when aggregate functions are used.
-    public private (set) var havingClause: SelectionHaving?
+    public private (set) var havingClause: QueryHavingProtocol?
     
     /// The SQL UNION clauses.
     public private (set) var unions: [Union]?
     
     /// The SQL JOIN, ON and USING clauses.
-    /// ON clause can be represented as `Filter` or raw SQL.
-    public private (set) var joins = [(join: Join, on: SelectionFilter?, using: [Column]?)]()
+    /// ON clause can be represented as `Filter` or a `String` containing raw SQL.
+    public private (set) var joins = [(join: Join, on: QueryFilterProtocol?, using: [Column]?)]()
 
     /// The SQL USING clause: an array of `Column` elements that have to match in a JOIN query.
 
@@ -222,7 +222,7 @@ public struct Select: Query {
     ///
     /// - Parameter clause: The `Having` clause or a `String` containing SQL HAVING clause to apply.
     /// - Returns: A new instance of Select with the `Having` clause.
-    public func having(_ clause: SelectionHaving) -> Select {
+    public func having(_ clause: QueryHavingProtocol) -> Select {
         var new = self
         if self.havingClause != nil {
             new.syntaxError += "Multiple having clauses. "
@@ -298,7 +298,7 @@ public struct Select: Query {
     ///
     /// - Parameter conditions: The `Filter` clause or a `String` containing SQL WHERE clause to apply.
     /// - Returns: A new instance of Select with the WHERE clause.
-    public func `where`(_ conditions: SelectionFilter) -> Select {
+    public func `where`(_ conditions: QueryFilterProtocol) -> Select {
         var new = self
         if self.whereClause != nil {
             new.syntaxError += "Multiple where clauses. "
@@ -312,7 +312,7 @@ public struct Select: Query {
     ///
     /// - Parameter conditions: The `Filter` clause or a `String` containing SQL ON clause to apply.
     /// - Returns: A new instance of Select with the ON clause.
-    public func on(_ conditions: SelectionFilter) -> Select {
+    public func on(_ conditions: QueryFilterProtocol) -> Select {
         var new = self
         
         guard new.joins.count > 0 else {
@@ -469,30 +469,5 @@ public struct Select: Query {
         var new = self
         new.joins.append((.naturalFull(table), nil, nil))
         return new
-    }
-}
-
-
-public protocol SelectionFilter: Buildable {
-    
-}
-
-extension Filter: SelectionFilter {
-    
-}
-
-
-public protocol SelectionHaving: Buildable {
-    
-}
-
-extension Having: SelectionHaving {
-    
-}
-
-extension String: SelectionFilter, SelectionHaving {
-    
-    public func build(queryBuilder: QueryBuilder) throws -> String {
-        return self
     }
 }

--- a/Sources/String+Buildable.swift
+++ b/Sources/String+Buildable.swift
@@ -1,0 +1,22 @@
+/**
+ Copyright IBM Corporation 2016
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+extension String: QueryFilterProtocol, QueryHavingProtocol {
+    
+    public func build(queryBuilder: QueryBuilder) throws -> String {
+        return self
+    }
+}

--- a/Sources/String+Buildable.swift
+++ b/Sources/String+Buildable.swift
@@ -14,8 +14,17 @@
  limitations under the License.
  */
 
+// MARK: String extensions
+
+/// The String extension with `QueryFilterProtocol` and `QueryHavingProtocol`.
+/// Enables the use if `String` in query as filtering clauses.
 extension String: QueryFilterProtocol, QueryHavingProtocol {
     
+    /// Process `String` as raw SQL using `QueryBuilder`.
+    ///
+    /// - Parameter queryBuilder: The QueryBuilder to use.
+    /// - Returns: A String representation of the query.
+    /// - Throws: QueryError.syntaxError if query build fails.
     public func build(queryBuilder: QueryBuilder) throws -> String {
         return self
     }

--- a/Sources/Update.swift
+++ b/Sources/Update.swift
@@ -22,10 +22,7 @@ public struct Update: Query {
     public let table: Table
 
     /// The SQL WHERE clause containing the filter for the rows to update.
-    public private (set) var whereClause: Filter?
-    
-    /// A String containg the raw SQL WHERE clause to filter the rows to update.
-    public private (set) var rawWhereClause: String?
+    public private (set) var whereClause: QueryFilterProtocol?
     
     /// A `Returning` enum value corresponding to the SQL RETURNING clause.
     public private (set) var returningClause: Returning?
@@ -39,7 +36,7 @@ public struct Update: Query {
     /// - Parameter table: The table to update.
     /// - Parameter set: An array of (column, value) tuples to set.
     /// - Parameter conditions: An optional where clause to apply.
-    public init(_ table: Table, set: [(Column, Any)], where conditions: Filter?=nil) {
+    public init(_ table: Table, set: [(Column, Any)], where conditions: QueryFilterProtocol?=nil) {
         self.table = table
         self.valueTuples = set
         self.whereClause = conditions
@@ -61,11 +58,8 @@ public struct Update: Query {
         result += try " SET " + valueTuples.map {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
-       if let whereClause = whereClause {
+        if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
-        }
-        else if let rawWhereClause = rawWhereClause {
-            result += " WHERE " + rawWhereClause
         }
         if let returning = returningClause {
             result += try " RETURNING " + returning.build(queryBuilder: queryBuilder)
@@ -76,30 +70,15 @@ public struct Update: Query {
     
     /// Add an SQL WHERE clause to the update statement.
     ///
-    /// - Parameter conditions: The SQL WHERE clause to apply.
+    /// - Parameter conditions: The `Filter` clause or a `String` containing the SQL WHERE to apply.
     /// - Returns: A new instance of Update.
     public func `where`(_ conditions: Filter) -> Update {
         var new = self
-        if whereClause != nil || rawWhereClause != nil {
+        if whereClause != nil {
             new.syntaxError += "Multiple where clauses. "
         }
         else {
             new.whereClause = conditions
-        }
-        return new
-    }
-
-    /// Add a raw SQL WHERE clause to the update statement.
-    ///
-    /// - Parameter conditions: A String containing the SQL WHERE clause to apply.
-    /// - Returns: A new instance of Update.
-    public func `where`(_ raw: String) -> Update {
-        var new = self
-        if whereClause != nil || rawWhereClause != nil {
-            new.syntaxError += "Multiple where clauses. "
-        }
-        else {
-            new.rawWhereClause = raw
         }
         return new
     }

--- a/Sources/Update.swift
+++ b/Sources/Update.swift
@@ -22,6 +22,7 @@ public struct Update: Query {
     public let table: Table
 
     /// The SQL WHERE clause containing the filter for the rows to update.
+    /// Could be represented with the `Filter` clause or a `String` containing raw SQL.
     public private (set) var whereClause: QueryFilterProtocol?
     
     /// A `Returning` enum value corresponding to the SQL RETURNING clause.

--- a/Sources/Update.swift
+++ b/Sources/Update.swift
@@ -72,7 +72,7 @@ public struct Update: Query {
     ///
     /// - Parameter conditions: The `Filter` clause or a `String` containing the SQL WHERE to apply.
     /// - Returns: A new instance of Update.
-    public func `where`(_ conditions: Filter) -> Update {
+    public func `where`(_ conditions: QueryFilterProtocol) -> Update {
         var new = self
         if whereClause != nil {
             new.syntaxError += "Multiple where clauses. "


### PR DESCRIPTION
I've added a `QueryFilterProtocol` and `QueryHavingProtocol` protocols, that is used in `Select` for `where`, `on` and `having` clauses and in `Update` for `where`.  

This removes possible errors where raw or Typed clause isn't used in `.build` method.

This also gives access for using different parameter types for `.where`, `.on` and `.having` methods in `Select` without implementing new methods.