### PR TITLE
Use protocol for suffix clauses

### DIFF
--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -26,7 +26,7 @@ public struct Delete: Query {
     public private (set) var whereClause: QueryFilterProtocol?
 
     /// A String with a clause to be appended to the end of the query.
-    public private (set) var rawSuffix: String?
+    public private (set) var suffix: QuerySuffixProtocol?
     
     private var syntaxError = ""
 
@@ -52,8 +52,8 @@ public struct Delete: Query {
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }
-        if let rawSuffix = rawSuffix {
-            result += " " + rawSuffix
+        if let suffix = suffix {
+            result += try " " + suffix.build(queryBuilder: queryBuilder)
         }
         result = updateParameterNumbers(query: result, queryBuilder: queryBuilder)
         return result
@@ -78,13 +78,13 @@ public struct Delete: Query {
     ///
     /// - Parameter raw: A String with a clause to be appended to the end of the query.
     /// - Returns: A new instance of Delete.
-    public func rawSuffix(_ raw: String) -> Delete {
+    public func suffix(_ raw: String) -> Delete {
         var new = self
-        if rawSuffix != nil {
-            new.syntaxError += "Multiple raw suffixes. "
+        if suffix != nil {
+            new.syntaxError += "Multiple suffixes. "
         }
         else {
-            new.rawSuffix = raw
+            new.suffix = raw
         }
         return new
     }

--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -28,7 +28,7 @@ public struct Insert: Query {
     public private (set) var values: [[Any]]?
     
     /// A String with a clause to be appended to the end of the query.
-    public private (set) var rawSuffix: String?
+    public private (set) var suffix: QuerySuffixProtocol?
     
     /// The select query that retrieves the rows to insert (for INSERT INTO SELECT).
     public private (set) var query: Select?
@@ -146,8 +146,8 @@ public struct Insert: Query {
         else {
             throw QueryError.syntaxError("Insert query doesn't have any values to insert.")
         }
-        if let rawSuffix = rawSuffix {
-            result += " " + rawSuffix
+        if let suffix = suffix {
+            result += try " " + suffix.build(queryBuilder: queryBuilder)
         }
         result = updateParameterNumbers(query: result, queryBuilder: queryBuilder)
         return result
@@ -157,13 +157,13 @@ public struct Insert: Query {
     ///
     /// - Parameter raw: A String with a clause to be appended to the end of the query.
     /// - Returns: A new instance of Insert.
-    public func rawSuffix(_ raw: String) -> Insert {
+    public func suffix(_ raw: String) -> Insert {
         var new = self
-        if rawSuffix != nil {
-            new.syntaxError += "Multiple raw suffixes. "
+        if suffix != nil {
+            new.syntaxError += "Multiple suffixes. "
         }
         else {
-            new.rawSuffix = raw
+            new.suffix = raw
         }
         return new
     }

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/QuerySuffixProtocol.swift
+++ b/Sources/SwiftKuery/QuerySuffixProtocol.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 // MARK: QuerySuffixProtocol
 
 /// Defines the protocol which should be used for all suffix clauses.
-/// Represents a suffix as String value.
 public protocol QuerySuffixProtocol: Buildable {
     
 }

--- a/Sources/SwiftKuery/QuerySuffixProtocol.swift
+++ b/Sources/SwiftKuery/QuerySuffixProtocol.swift
@@ -1,0 +1,23 @@
+/**
+ Copyright IBM Corporation 2016, 2017
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+// MARK: QuerySuffixProtocol
+
+/// Defines the protocol which should be used for all suffix clauses.
+/// Represents a suffix as String value.
+public protocol QuerySuffixProtocol: Buildable {
+    
+}

--- a/Sources/SwiftKuery/String+Buildable.swift
+++ b/Sources/SwiftKuery/String+Buildable.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 /// The String extension with `QueryFilterProtocol` and `QueryHavingProtocol`.
 /// Enables the use if `String` in query as filtering clauses.
-extension String: QueryFilterProtocol, QueryHavingProtocol {
+extension String: QueryFilterProtocol, QueryHavingProtocol, QuerySuffixProtocol {
     
     /// Process `String` as raw SQL using `QueryBuilder`.
     ///

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -26,7 +26,7 @@ public struct Update: Query {
     public private (set) var whereClause: QueryFilterProtocol?
     
     /// A String with a clause to be appended to the end of the query.
-    public private (set) var rawSuffix: String?
+    public private (set) var suffix: QuerySuffixProtocol?
     
     private let valueTuples: [(Column, Any)]
     
@@ -62,8 +62,8 @@ public struct Update: Query {
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }
-        if let rawSuffix = rawSuffix {
-            result += " " + rawSuffix
+        if let suffix = suffix {
+            result += try " " + suffix.build(queryBuilder: queryBuilder)
         }
         result = updateParameterNumbers(query: result, queryBuilder: queryBuilder)
         return result
@@ -88,13 +88,13 @@ public struct Update: Query {
     ///
     /// - Parameter raw: A String with a clause to be appended to the end of the query.
     /// - Returns: A new instance of Update.
-    public func rawSuffix(_ raw: String) -> Update {
+    public func suffix(_ raw: String) -> Update {
         var new = self
-        if rawSuffix != nil {
-            new.syntaxError += "Multiple raw suffixes. "
+        if suffix != nil {
+            new.syntaxError += "Multiple suffixes. "
         }
         else {
-            new.rawSuffix = raw
+            new.suffix = raw
         }
         return new
     }

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -60,7 +60,7 @@ class TestInsert: XCTestCase {
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         i = Insert(into: t, columns: [t.a, t.b], values: ["banana", 17])
-            .rawSuffix("RETURNING *")
+            .suffix("RETURNING *")
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO tableInsert (a, b) VALUES ('banana', 17) RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
@@ -72,7 +72,7 @@ class TestInsert: XCTestCase {
         
         let t2 = MyTable2()
         i = Insert(into: t, columns: [t.a], Select(t2.a, from: t2))
-            .rawSuffix("RETURNING a")
+            .suffix("RETURNING a")
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO tableInsert (a) SELECT tableInsert2.a FROM tableInsert2 RETURNING a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryTests/TestSyntaxError.swift
+++ b/Tests/SwiftKueryTests/TestSyntaxError.swift
@@ -74,14 +74,14 @@ class TestSyntaxError: XCTestCase {
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .where(t.a == "banana")
             .where(t.b == 7)
-            .rawSuffix("RETURNING *")
-            .rawSuffix("RETURNING a")
+            .suffix("RETURNING *")
+            .suffix("RETURNING a")
         do {
             let _ = try u.build(queryBuilder: connection.queryBuilder)
             XCTFail("No syntax error.")
         }
         catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple where clauses. Multiple raw suffixes. ")
+            XCTAssertEqual(error, "Multiple where clauses. Multiple suffixes. ")
         }
         catch {
             XCTFail("Other than syntax error.")
@@ -91,14 +91,14 @@ class TestSyntaxError: XCTestCase {
             .where("a == \"apple\"")
             .where(t.b == "2")
             .where(t.b == 7)
-            .rawSuffix("RETURNING *")
-            .rawSuffix("RETURNING a")
+            .suffix("RETURNING *")
+            .suffix("RETURNING a")
         do {
             let _ = try d.build(queryBuilder: connection.queryBuilder)
             XCTFail("No syntax error.")
         }
         catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple where clauses. Multiple where clauses. Multiple raw suffixes. ")
+            XCTAssertEqual(error, "Multiple where clauses. Multiple where clauses. Multiple suffixes. ")
         }
         catch {
             XCTFail("Other than syntax error.")
@@ -129,14 +129,14 @@ class TestSyntaxError: XCTestCase {
         }
 
         let i3 = Insert(into: t, values: "apple", 10)
-            .rawSuffix("RETURNING *")
-            .rawSuffix("RETURNING *")
+            .suffix("RETURNING *")
+            .suffix("RETURNING *")
         do {
             let _ = try i3.build(queryBuilder: connection.queryBuilder)
             XCTFail("No syntax error.")
         }
         catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple raw suffixes. ")
+            XCTAssertEqual(error, "Multiple suffixes. ")
         }
         catch {
             XCTFail("Other than syntax error.")

--- a/Tests/SwiftKueryTests/TestSyntaxError.swift
+++ b/Tests/SwiftKueryTests/TestSyntaxError.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -44,19 +44,19 @@ class TestUpdate: XCTestCase {
  
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .where(t.a == "banana")
-            .rawSuffix("RETURNING *")
+            .suffix("RETURNING *")
         kuery = connection.descriptionOf(query: u)
         query = "UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = 'banana' RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
  
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
-            .rawSuffix("RETURNING b,a")
+            .suffix("RETURNING b,a")
         kuery = connection.descriptionOf(query: u)
         query = "UPDATE tableUpdate SET a = 'peach', b = 2 RETURNING b,a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
-            .rawSuffix("RETURNING tableUpdate.b")
+            .suffix("RETURNING tableUpdate.b")
         kuery = connection.descriptionOf(query: u)
         query = "UPDATE tableUpdate SET a = 'peach', b = 2 RETURNING tableUpdate.b"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2016, 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added a protocol for suffix clauses. This would simplify the use of `suffix` and would allow an extensions like `returning` method for PostgreSQL and other data bases that support it.