### PR TITLE
Revert WITH clause for UPDATE, DELETE

### DIFF
--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -28,9 +28,6 @@ public struct Delete: Query {
     /// A String with a clause to be appended to the end of the query.
     public private (set) var suffix: QuerySuffixProtocol?
     
-    /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
-    public private (set) var with: [AuxiliaryTable]?
-    
     private var syntaxError = ""
 
     /// Initialize an instance of Delete.
@@ -51,18 +48,7 @@ public struct Delete: Query {
         if syntaxError != "" {
             throw QueryError.syntaxError(syntaxError)
         }
-        
-        var result = ""
-        
-        if let with = with {
-            result += "WITH "
-                + "\(try with.map { try $0.buildWith(queryBuilder: queryBuilder) }.joined(separator: ", "))"
-                + " "
-        }
-        
-        result += "DELETE FROM "
-        
-        result += try table.build(queryBuilder: queryBuilder)
+        var result = try "DELETE FROM " + table.build(queryBuilder: queryBuilder)
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }
@@ -103,18 +89,4 @@ public struct Delete: Query {
         return new
     }
 
-    /// Set tables to be used for WITH clause.
-    ///
-    /// - Parameter tables: A list of the `AuxiliaryTable` to apply.
-    /// - Returns: A new instance of Delete with tables for WITH clause.
-    func with(_ tables: [AuxiliaryTable]) -> Delete {
-        var new = self
-        if new.with != nil {
-            new.syntaxError += "Multiple with clauses. "
-        }
-        else {
-            new.with = tables
-        }
-        return new
-    }
 }

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -30,9 +30,6 @@ public struct Update: Query {
     
     private let valueTuples: [(Column, Any)]
     
-    /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
-    public private (set) var with: [AuxiliaryTable]?
-    
     private var syntaxError = ""
     
     /// Initialize an instance of Update.
@@ -58,18 +55,7 @@ public struct Update: Query {
         if syntaxError != "" {
             throw QueryError.syntaxError(syntaxError)
         }
-        
-        var result = ""
-        
-        if let with = with {
-            result += "WITH "
-                + "\(try with.map { try $0.buildWith(queryBuilder: queryBuilder) }.joined(separator: ", "))"
-                + " "
-        }
-        
-        result += "UPDATE "
-        
-        result += try table.build(queryBuilder: queryBuilder)
+        var result = try "UPDATE " + table.build(queryBuilder: queryBuilder)
         result += try " SET " + valueTuples.map {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
@@ -109,21 +95,6 @@ public struct Update: Query {
         }
         else {
             new.suffix = raw
-        }
-        return new
-    }
-    
-    /// Set tables to be used for WITH clause.
-    ///
-    /// - Parameter tables: A list of the `AuxiliaryTable` to apply.
-    /// - Returns: A new instance of Update with tables for WITH clause.
-    func with(_ tables: [AuxiliaryTable]) -> Update {
-        var new = self
-        if new.with != nil {
-            new.syntaxError += "Multiple with clauses. "
-        }
-        else {
-            new.with = tables
         }
         return new
     }

--- a/Sources/SwiftKuery/With.swift
+++ b/Sources/SwiftKuery/With.swift
@@ -49,38 +49,3 @@ public func with(_ table: AuxiliaryTable, _ query: Insert) -> Insert {
 public func with(_ tables: [AuxiliaryTable], _ query: Insert) -> Insert {
     return query.with(tables)
 }
-
-
-/// Create a query with a WITH clause.
-///
-/// - Parameter table: A table for a WITH clause.
-/// - Parameter query: An UPDATE query that will use the table from the WITH clause.
-public func with(_ table: AuxiliaryTable, _ query: Update) -> Update {
-    return with([table], query)
-}
-
-/// Create a query with a WITH clause.
-///
-/// - Parameter tables: An array of tables for a WITH clause.
-/// - Parameter query: An UPDATE query that will use the table from the WITH clause.
-public func with(_ tables: [AuxiliaryTable], _ query: Update) -> Update {
-    return query.with(tables)
-}
-
-
-/// Create a query with a WITH clause.
-///
-/// - Parameter table: A table for a WITH clause.
-/// - Parameter query: A DELETE query that will use the table from the WITH clause.
-public func with(_ table: AuxiliaryTable, _ query: Delete) -> Delete {
-    return with([table], query)
-}
-
-/// Create a query with a WITH clause.
-///
-/// - Parameter tables: An array of tables for a WITH clause.
-/// - Parameter query: A DELETE query that will use the table from the WITH clause.
-public func with(_ tables: [AuxiliaryTable], _ query: Delete) -> Delete {
-    return query.with(tables)
-}
-

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -22,7 +22,6 @@ class TestUpdate: XCTestCase {
     static var allTests: [(String, (TestUpdate) -> () throws -> Void)] {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
-            ("testUpdateAndDeleteWith", testUpdateAndDeleteWith),
         ]
     }
     
@@ -79,77 +78,5 @@ class TestUpdate: XCTestCase {
         kuery = connection.descriptionOf(query: d)
         query = "DELETE FROM tableUpdate"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-    }
-    
-    func testUpdateAndDeleteWith() {
-        let t = MyTable()
-        let t2 = MyTable2()
-        let connection = createConnection()
-
-        class AuxTable: AuxiliaryTable {
-            let tableName = "aux_table"
-            
-            let c = Column("c")
-        }
-
-        var withTable = AuxTable(as: Select(t2.a.as("c"), from: t2))
-        var u = with(withTable,
-                     Update(t, set: [(t.a, "peach"), (t.b, 2)])
-                        .where(t.a == withTable.c))
-        var kuery = connection.descriptionOf(query: u)
-        var query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = aux_table.c"
-        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-        
-        var d = with(withTable,
-                     Delete(from: t)
-                        .where(t.b == withTable.c))
-        kuery = connection.descriptionOf(query: d)
-        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate WHERE tableUpdate.b = aux_table.c"
-        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-        
-        withTable = AuxTable()
-        u = with(withTable,
-                     Update(t, set: [(t.a, "peach"), (t.b, 2)])
-                        .where(t.a == withTable.c))
-        do {
-            let _ = try u.build(queryBuilder: connection.queryBuilder)
-            XCTFail("No syntax error.")
-        } catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "With query was not specified. ")
-        } catch {
-            XCTFail("Other than syntax error.")
-        }
-        
-        d = with(withTable,
-                 Delete(from: t)
-                    .where(t.b == withTable.c))
-        do {
-            let _ = try u.build(queryBuilder: connection.queryBuilder)
-            XCTFail("No syntax error.")
-        } catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "With query was not specified. ")
-        } catch {
-            XCTFail("Other than syntax error.")
-        }
-        
-        u = with(withTable, u)
-        do {
-            let _ = try u.build(queryBuilder: connection.queryBuilder)
-            XCTFail("No syntax error.")
-        } catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple with clauses. ")
-        } catch {
-            XCTFail("Other than syntax error.")
-        }
-        
-        d = with(withTable, d)
-        do {
-            let _ = try d.build(queryBuilder: connection.queryBuilder)
-            XCTFail("No syntax error.")
-        } catch QueryError.syntaxError(let error) {
-            XCTAssertEqual(error, "Multiple with clauses. ")
-        } catch {
-            XCTFail("Other than syntax error.")
-        }
     }
 }


### PR DESCRIPTION
Removes `WITH` clauses for `UPDATE` and `DELETE`.
Fixes #52 

I'll implement an Extension points for `Query` type in next PR.