### PR TITLE
WITH clause for UPDATE, DELETE

### DIFF
--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -64,8 +64,8 @@ public struct Delete: Query {
         
         result += try table.build(queryBuilder: queryBuilder)
         
-        if queryBuilder.withDeleteRequiresUsing,
-            let with = with {
+        if let with = with,
+            queryBuilder.withDeleteRequiresUsing {
             result += try " USING " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
         }
         

--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -28,6 +28,9 @@ public struct Delete: Query {
     /// A String with a clause to be appended to the end of the query.
     public private (set) var suffix: QuerySuffixProtocol?
     
+    /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
+    public private (set) var with: [AuxiliaryTable]?
+    
     private var syntaxError = ""
 
     /// Initialize an instance of Delete.
@@ -48,7 +51,18 @@ public struct Delete: Query {
         if syntaxError != "" {
             throw QueryError.syntaxError(syntaxError)
         }
-        var result = try "DELETE FROM " + table.build(queryBuilder: queryBuilder)
+        
+        var result = ""
+        
+        if let with = with {
+            result += "WITH "
+                + "\(try with.map { try $0.buildWith(queryBuilder: queryBuilder) }.joined(separator: ", "))"
+                + " "
+        }
+        
+        result += "DELETE FROM "
+        
+        result += try table.build(queryBuilder: queryBuilder)
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }
@@ -89,4 +103,18 @@ public struct Delete: Query {
         return new
     }
 
+    /// Set tables to be used for WITH clause.
+    ///
+    /// - Parameter tables: A list of the `AuxiliaryTable` to apply.
+    /// - Returns: A new instance of Delete with tables for WITH clause.
+    func with(_ tables: [AuxiliaryTable]) -> Delete {
+        var new = self
+        if new.with != nil {
+            new.syntaxError += "Multiple with clauses. "
+        }
+        else {
+            new.with = tables
+        }
+        return new
+    }
 }

--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -64,7 +64,7 @@ public struct Delete: Query {
         
         result += try table.build(queryBuilder: queryBuilder)
         
-        if queryBuilder.database == .postgreSQL,
+        if queryBuilder.withDeleteRequiresUsing,
             let with = with {
             result += try " USING " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
         }

--- a/Sources/SwiftKuery/Delete.swift
+++ b/Sources/SwiftKuery/Delete.swift
@@ -63,6 +63,12 @@ public struct Delete: Query {
         result += "DELETE FROM "
         
         result += try table.build(queryBuilder: queryBuilder)
+        
+        if queryBuilder.database == .postgreSQL,
+            let with = with {
+            result += try " USING " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
+        }
+        
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -54,7 +54,7 @@ public class QueryBuilder {
     public var firstParameterIndex = 1
     /// An indication whether ANY on subqueries is supported.
     public var anyOnSubquerySupported = true
-    /// An indication whether an `DELETE` query should use `USING` clause for tables in `WITH` clause.
+    /// An indication whether a `DELETE` query should use `USING` clause for tables in `WITH` clause.
     public var withDeleteRequiresUsing = false
     /// An indication whether an `UPDATE` query should use `FROM` clause for tables in `WITH` clause.
     public var withUpdateRequiresFrom = false

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -47,14 +47,6 @@ public class QueryBuilder {
         case namesCount
     }
     
-    /// Database types that could be used for building a query 
-    /// and supported by `Swift-Kuery`
-    public enum Database: String {
-        case unknown
-        case postgreSQL
-        case sqLite
-    }
-    
     /// An indication whether the parameters should be numbered (e.g., '$1, $2'), or just marked
     /// with the numbered parameter marker (e.g., '?').
     public var addNumbersToParameters = true
@@ -62,15 +54,18 @@ public class QueryBuilder {
     public var firstParameterIndex = 1
     /// An indication whether ANY on subqueries is supported.
     public var anyOnSubquerySupported = true
-    /// A database type used for building a query
-    public var database: Database = .unknown
+    /// An indication whether an `DELETE` query should use `USING` clause for tables in `WITH` clause.
+    public var withDeleteRequiresUsing = false
+    /// An indication whether an `UPDATE` query should use `FROM` clause for tables in `WITH` clause.
+    public var withUpdateRequiresFrom = false
+    
     
     /// Initialize an instance of QueryBuilder.
     ///
     /// - Parameter addNumbersToParameters: An indication whether query parameters should be numbered.
     /// - Parameter firstParameterIndex: The starting index for numbered parameters.
     /// - Parameter anyOnSubquerySupported: An indication whether ANY on subqueries is supported.
-    public init(addNumbersToParameters: Bool?=nil, firstParameterIndex: Int?=nil, anyOnSubquerySupported: Bool?=nil, database: Database = .unknown) {
+    public init(addNumbersToParameters: Bool?=nil, firstParameterIndex: Int?=nil, anyOnSubquerySupported: Bool?=nil, withDeleteRequiresUsing: Bool? = nil, withUpdateRequiresFrom: Bool? = nil) {
         substitutions = Array(repeating: "", count: QuerySubstitutionNames.namesCount.rawValue)
         substitutions[QuerySubstitutionNames.ucase.rawValue] = "UCASE"
         substitutions[QuerySubstitutionNames.lcase.rawValue] = "LCASE"
@@ -88,7 +83,12 @@ public class QueryBuilder {
             self.firstParameterIndex = firstParameterIndex
         }
         
-        self.database = database
+        if let withDeleteRequiresUsing = withDeleteRequiresUsing {
+            self.withDeleteRequiresUsing = withDeleteRequiresUsing
+        }
+        if let withUpdateRequiresFrom = withUpdateRequiresFrom {
+            self.withUpdateRequiresFrom = withUpdateRequiresFrom
+        }
     }
     
     /// Update substitutions array.

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -47,6 +47,14 @@ public class QueryBuilder {
         case namesCount
     }
     
+    /// Database types that could be used for building a query 
+    /// and supported by `Swift-Kuery`
+    public enum Database: String {
+        case unknown
+        case postgreSQL
+        case sqLite
+    }
+    
     /// An indication whether the parameters should be numbered (e.g., '$1, $2'), or just marked
     /// with the numbered parameter marker (e.g., '?').
     public var addNumbersToParameters = true
@@ -54,13 +62,15 @@ public class QueryBuilder {
     public var firstParameterIndex = 1
     /// An indication whether ANY on subqueries is supported.
     public var anyOnSubquerySupported = true
+    /// A database type used for building a query
+    public var database: Database = .unknown
     
     /// Initialize an instance of QueryBuilder.
     ///
     /// - Parameter addNumbersToParameters: An indication whether query parameters should be numbered.
     /// - Parameter firstParameterIndex: The starting index for numbered parameters.
     /// - Parameter anyOnSubquerySupported: An indication whether ANY on subqueries is supported.
-    public init(addNumbersToParameters: Bool?=nil, firstParameterIndex: Int?=nil, anyOnSubquerySupported: Bool?=nil) {
+    public init(addNumbersToParameters: Bool?=nil, firstParameterIndex: Int?=nil, anyOnSubquerySupported: Bool?=nil, database: Database = .unknown) {
         substitutions = Array(repeating: "", count: QuerySubstitutionNames.namesCount.rawValue)
         substitutions[QuerySubstitutionNames.ucase.rawValue] = "UCASE"
         substitutions[QuerySubstitutionNames.lcase.rawValue] = "LCASE"
@@ -77,6 +87,8 @@ public class QueryBuilder {
         if let firstParameterIndex = firstParameterIndex {
             self.firstParameterIndex = firstParameterIndex
         }
+        
+        self.database = database
     }
     
     /// Update substitutions array.

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -30,6 +30,9 @@ public struct Update: Query {
     
     private let valueTuples: [(Column, Any)]
     
+    /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
+    public private (set) var with: [AuxiliaryTable]?
+    
     private var syntaxError = ""
     
     /// Initialize an instance of Update.
@@ -55,7 +58,18 @@ public struct Update: Query {
         if syntaxError != "" {
             throw QueryError.syntaxError(syntaxError)
         }
-        var result = try "UPDATE " + table.build(queryBuilder: queryBuilder)
+        
+        var result = ""
+        
+        if let with = with {
+            result += "WITH "
+                + "\(try with.map { try $0.buildWith(queryBuilder: queryBuilder) }.joined(separator: ", "))"
+                + " "
+        }
+        
+        result += "UPDATE "
+        
+        result += try table.build(queryBuilder: queryBuilder)
         result += try " SET " + valueTuples.map {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
@@ -95,6 +109,21 @@ public struct Update: Query {
         }
         else {
             new.suffix = raw
+        }
+        return new
+    }
+    
+    /// Set tables to be used for WITH clause.
+    ///
+    /// - Parameter tables: A list of the `AuxiliaryTable` to apply.
+    /// - Returns: A new instance of Update with tables for WITH clause.
+    func with(_ tables: [AuxiliaryTable]) -> Update {
+        var new = self
+        if new.with != nil {
+            new.syntaxError += "Multiple with clauses. "
+        }
+        else {
+            new.with = tables
         }
         return new
     }

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -74,7 +74,7 @@ public struct Update: Query {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
         
-        if queryBuilder.database == .postgreSQL,
+        if queryBuilder.withDeleteRequiresUsing,
             let with = with {
             result += try " FROM " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
         }

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -73,6 +73,12 @@ public struct Update: Query {
         result += try " SET " + valueTuples.map {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
+        
+        if queryBuilder.database == .postgreSQL,
+            let with = with {
+            result += try " FROM " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
+        }
+        
         if let whereClause = whereClause {
             result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
         }

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -74,8 +74,8 @@ public struct Update: Query {
             column, value in "\(column.name) = \(try packType(value, queryBuilder: queryBuilder))"
             }.joined(separator: ", ")
         
-        if queryBuilder.withDeleteRequiresUsing,
-            let with = with {
+        if let with = with,
+            queryBuilder.withDeleteRequiresUsing {
             result += try " FROM " + with.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", ")
         }
         

--- a/Sources/SwiftKuery/With.swift
+++ b/Sources/SwiftKuery/With.swift
@@ -49,3 +49,38 @@ public func with(_ table: AuxiliaryTable, _ query: Insert) -> Insert {
 public func with(_ tables: [AuxiliaryTable], _ query: Insert) -> Insert {
     return query.with(tables)
 }
+
+
+/// Create a query with a WITH clause.
+///
+/// - Parameter table: A table for a WITH clause.
+/// - Parameter query: An UPDATE query that will use the table from the WITH clause.
+public func with(_ table: AuxiliaryTable, _ query: Update) -> Update {
+    return with([table], query)
+}
+
+/// Create a query with a WITH clause.
+///
+/// - Parameter tables: An array of tables for a WITH clause.
+/// - Parameter query: An UPDATE query that will use the table from the WITH clause.
+public func with(_ tables: [AuxiliaryTable], _ query: Update) -> Update {
+    return query.with(tables)
+}
+
+
+/// Create a query with a WITH clause.
+///
+/// - Parameter table: A table for a WITH clause.
+/// - Parameter query: A DELETE query that will use the table from the WITH clause.
+public func with(_ table: AuxiliaryTable, _ query: Delete) -> Delete {
+    return with([table], query)
+}
+
+/// Create a query with a WITH clause.
+///
+/// - Parameter tables: An array of tables for a WITH clause.
+/// - Parameter query: A DELETE query that will use the table from the WITH clause.
+public func with(_ tables: [AuxiliaryTable], _ query: Delete) -> Delete {
+    return query.with(tables)
+}
+

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -37,8 +37,8 @@ class TestConnection: Connection {
         case returnValue
     }
 
-    init(result: Result, type: QueryBuilder.Database = .unknown) {
-        self.queryBuilder = QueryBuilder(database: type)
+    init(result: Result, withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false) {
+        self.queryBuilder = QueryBuilder(withDeleteRequiresUsing: withDeleteRequiresUsing, withUpdateRequiresFrom: withUpdateRequiresFrom)
         self.result = result
     }
     
@@ -128,8 +128,8 @@ func createConnection(_ result: TestConnection.Result) -> TestConnection {
     return TestConnection(result: result)
 }
 
-func createConnection(type: QueryBuilder.Database = .unknown) -> TestConnection {
-    return TestConnection(result: .returnEmpty, type: type)
+func createConnection(withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false) -> TestConnection {
+    return TestConnection(result: .returnEmpty, withDeleteRequiresUsing: withDeleteRequiresUsing, withUpdateRequiresFrom: withUpdateRequiresFrom)
 }
 
 // Dummy class for test framework

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -37,8 +37,8 @@ class TestConnection: Connection {
         case returnValue
     }
 
-    init(result: Result) {
-        self.queryBuilder = QueryBuilder()
+    init(result: Result, type: QueryBuilder.Database = .unknown) {
+        self.queryBuilder = QueryBuilder(database: type)
         self.result = result
     }
     
@@ -128,8 +128,8 @@ func createConnection(_ result: TestConnection.Result) -> TestConnection {
     return TestConnection(result: result)
 }
 
-func createConnection() -> TestConnection {
-    return TestConnection(result: .returnEmpty)
+func createConnection(type: QueryBuilder.Database = .unknown) -> TestConnection {
+    return TestConnection(result: .returnEmpty, type: type)
 }
 
 // Dummy class for test framework

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -85,6 +85,7 @@ class TestUpdate: XCTestCase {
         let t = MyTable()
         let t2 = MyTable2()
         let connection = createConnection()
+        let psqlConnection = createConnection(type: .postgreSQL)
 
         class AuxTable: AuxiliaryTable {
             let tableName = "aux_table"
@@ -99,12 +100,19 @@ class TestUpdate: XCTestCase {
         var kuery = connection.descriptionOf(query: u)
         var query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = aux_table.c"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        kuery = psqlConnection.descriptionOf(query: u)
+        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 FROM aux_table WHERE tableUpdate.a = aux_table.c"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
         
         var d = with(withTable,
                      Delete(from: t)
                         .where(t.b == withTable.c))
         kuery = connection.descriptionOf(query: d)
         query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate WHERE tableUpdate.b = aux_table.c"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        kuery = psqlConnection.descriptionOf(query: d)
+        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate USING aux_table WHERE tableUpdate.b = aux_table.c"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         withTable = AuxTable()

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -85,7 +85,7 @@ class TestUpdate: XCTestCase {
         let t = MyTable()
         let t2 = MyTable2()
         let connection = createConnection()
-        let psqlConnection = createConnection(withDeleteRequiresUsing: true, withUpdateRequiresFrom: true)
+        let connection2 = createConnection(withDeleteRequiresUsing: true, withUpdateRequiresFrom: true)
 
         class AuxTable: AuxiliaryTable {
             let tableName = "aux_table"
@@ -100,7 +100,7 @@ class TestUpdate: XCTestCase {
         var kuery = connection.descriptionOf(query: u)
         var query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a IN (SELECT aux_table.c FROM aux_table)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-        kuery = psqlConnection.descriptionOf(query: u)
+        kuery = connection2.descriptionOf(query: u)
         query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 FROM aux_table WHERE tableUpdate.a IN (SELECT aux_table.c FROM aux_table)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
@@ -111,7 +111,7 @@ class TestUpdate: XCTestCase {
         kuery = connection.descriptionOf(query: d)
         query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate WHERE tableUpdate.b IN (SELECT aux_table.c FROM aux_table)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-        kuery = psqlConnection.descriptionOf(query: d)
+        kuery = connection2.descriptionOf(query: d)
         query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate USING aux_table WHERE tableUpdate.b IN (SELECT aux_table.c FROM aux_table)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -22,6 +22,7 @@ class TestUpdate: XCTestCase {
     static var allTests: [(String, (TestUpdate) -> () throws -> Void)] {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
+            ("testUpdateAndDeleteWith", testUpdateAndDeleteWith),
         ]
     }
     
@@ -78,5 +79,77 @@ class TestUpdate: XCTestCase {
         kuery = connection.descriptionOf(query: d)
         query = "DELETE FROM tableUpdate"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+    }
+    
+    func testUpdateAndDeleteWith() {
+        let t = MyTable()
+        let t2 = MyTable2()
+        let connection = createConnection()
+
+        class AuxTable: AuxiliaryTable {
+            let tableName = "aux_table"
+            
+            let c = Column("c")
+        }
+
+        var withTable = AuxTable(as: Select(t2.a.as("c"), from: t2))
+        var u = with(withTable,
+                     Update(t, set: [(t.a, "peach"), (t.b, 2)])
+                        .where(t.a == withTable.c))
+        var kuery = connection.descriptionOf(query: u)
+        var query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = aux_table.c"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
+        var d = with(withTable,
+                     Delete(from: t)
+                        .where(t.b == withTable.c))
+        kuery = connection.descriptionOf(query: d)
+        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate WHERE tableUpdate.b = aux_table.c"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
+        withTable = AuxTable()
+        u = with(withTable,
+                     Update(t, set: [(t.a, "peach"), (t.b, 2)])
+                        .where(t.a == withTable.c))
+        do {
+            let _ = try u.build(queryBuilder: connection.queryBuilder)
+            XCTFail("No syntax error.")
+        } catch QueryError.syntaxError(let error) {
+            XCTAssertEqual(error, "With query was not specified. ")
+        } catch {
+            XCTFail("Other than syntax error.")
+        }
+        
+        d = with(withTable,
+                 Delete(from: t)
+                    .where(t.b == withTable.c))
+        do {
+            let _ = try u.build(queryBuilder: connection.queryBuilder)
+            XCTFail("No syntax error.")
+        } catch QueryError.syntaxError(let error) {
+            XCTAssertEqual(error, "With query was not specified. ")
+        } catch {
+            XCTFail("Other than syntax error.")
+        }
+        
+        u = with(withTable, u)
+        do {
+            let _ = try u.build(queryBuilder: connection.queryBuilder)
+            XCTFail("No syntax error.")
+        } catch QueryError.syntaxError(let error) {
+            XCTAssertEqual(error, "Multiple with clauses. ")
+        } catch {
+            XCTFail("Other than syntax error.")
+        }
+        
+        d = with(withTable, d)
+        do {
+            let _ = try d.build(queryBuilder: connection.queryBuilder)
+            XCTFail("No syntax error.")
+        } catch QueryError.syntaxError(let error) {
+            XCTAssertEqual(error, "Multiple with clauses. ")
+        } catch {
+            XCTFail("Other than syntax error.")
+        }
     }
 }


### PR DESCRIPTION
Implemented a temporary workaround for `UPDATE` and `DELETE` clauses for PostgreSQL which was discussed in #52.
Added a test cases to cover a workaround.