### PR TITLE
Make identifier quote character for packName() customizable

### DIFF
--- a/Sources/SwiftKuery/AggregateColumnExpression.swift
+++ b/Sources/SwiftKuery/AggregateColumnExpression.swift
@@ -37,7 +37,7 @@ public struct AggregateColumnExpression: Field {
     public func build(queryBuilder: QueryBuilder) throws -> String {
         var result = try function.build(queryBuilder: queryBuilder)
         if let alias = alias {
-            result += " AS " + packName(alias)
+            result += " AS " + packName(alias, queryBuilder: queryBuilder)
         }
         return result
     }

--- a/Sources/SwiftKuery/AggregateColumnExpression.swift
+++ b/Sources/SwiftKuery/AggregateColumnExpression.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/AuxiliaryTable.swift
+++ b/Sources/SwiftKuery/AuxiliaryTable.swift
@@ -39,7 +39,7 @@ open class AuxiliaryTable: Table {
         guard let query = query else {
             throw QueryError.syntaxError("With query was not specified. ")
         }
-        return nameInQuery + " AS " + "(" + (try query.build(queryBuilder: queryBuilder)) + ")"
+        return packName(nameInQuery, queryBuilder: queryBuilder) + " AS " + "(" + (try query.build(queryBuilder: queryBuilder)) + ")"
     }
     
 }

--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -40,13 +40,13 @@ public class Column: Field {
     /// - Returns: A String representation of the column.
     /// - Throws: QueryError.syntaxError if query build fails.
     public func build(queryBuilder: QueryBuilder) throws -> String {
-        let tableName = table.nameInQuery
+        let tableName = packName(table.nameInQuery, queryBuilder: queryBuilder)
         if tableName == "" {
             throw QueryError.syntaxError("Table name not set. ")
         }
-        var result = tableName + "." + packName(name)
+        var result = tableName + "." + packName(name, queryBuilder: queryBuilder)
         if let alias = alias {
-            result += " AS " + packName(alias)
+            result += " AS " + packName(alias, queryBuilder: queryBuilder)
         }
         return result
     }

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -43,6 +43,8 @@ public class QueryBuilder {
         case booleanFalse
         /// The ALL function for subqueries.
         case all
+        /// character used to quote identifiers (table name,column name, etc) with spaces or special characters
+        case identifierQuoteCharacter
         /// Last case, add new values before it.
         case namesCount
     }
@@ -81,7 +83,8 @@ public class QueryBuilder {
         substitutions[QuerySubstitutionNames.booleanTrue.rawValue] = "true"
         substitutions[QuerySubstitutionNames.booleanFalse.rawValue] = "false"
         substitutions[QuerySubstitutionNames.all.rawValue] = "ALL"
-        
+        substitutions[QuerySubstitutionNames.identifierQuoteCharacter.rawValue] = "\""
+
         if let addNumbersToParameters = addNumbersToParameters {
             self.addNumbersToParameters = addNumbersToParameters
         }

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class QueryBuilder {
         case booleanFalse
         /// The ALL function for subqueries.
         case all
-        /// character used to quote identifiers (table name,column name, etc) with spaces or special characters
+        /// The character used to quote identifiers (table name, column name, etc.) with spaces or special characters.
         case identifierQuoteCharacter
         /// Last case, add new values before it.
         case namesCount

--- a/Sources/SwiftKuery/ScalarColumnExpression.swift
+++ b/Sources/SwiftKuery/ScalarColumnExpression.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/ScalarColumnExpression.swift
+++ b/Sources/SwiftKuery/ScalarColumnExpression.swift
@@ -37,7 +37,7 @@ public struct ScalarColumnExpression: Field {
     public func build(queryBuilder: QueryBuilder) throws -> String {
         var result = try function.build(queryBuilder: queryBuilder)
         if let alias = alias {
-            result += " AS " + packName(alias)
+            result += " AS " + packName(alias, queryBuilder: queryBuilder)
         }
         return result
     }

--- a/Sources/SwiftKuery/Table.swift
+++ b/Sources/SwiftKuery/Table.swift
@@ -27,10 +27,7 @@ open class Table: Buildable {
     /// The name of the table to be used inside a query, i.e., either its alias (if exists)
     /// or its name.
     public var nameInQuery: String {
-        if let alias = alias {
-            return packName(alias)
-        }
-        return packName(_name)
+        return alias ?? _name
     }
 
     /// Initialize an instance of Table.
@@ -61,9 +58,9 @@ open class Table: Buildable {
         if _name == "" {
             throw QueryError.syntaxError("Table name not set. ")
         }
-        var result = packName(_name)
+        var result = packName(_name, queryBuilder: queryBuilder)
         if let alias = alias {
-            result += " AS " + packName(alias)
+            result += " AS " + packName(alias, queryBuilder: queryBuilder)
         }
         return result
     }

--- a/Sources/SwiftKuery/Table.swift
+++ b/Sources/SwiftKuery/Table.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016
+ Copyright IBM Corporation 2017
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
 
 func packName(_ name: String, queryBuilder: QueryBuilder) -> String {
     var result = name
-    let identQuoteChar = queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.identifierQuoteCharacter.rawValue]
-    if result.contains(" ") && !result.hasPrefix(identQuoteChar) {
-        result = identQuoteChar + result + identQuoteChar
+    let identifierQuoteCharacter = queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.identifierQuoteCharacter.rawValue]
+    if result.contains(" ") && !result.hasPrefix(identifierQuoteCharacter) {
+        result = identifierQuoteCharacter + result + identifierQuoteCharacter
     }
    return result
 }

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -39,10 +39,11 @@ func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
     }
 }
 
-func packName(_ name: String) -> String {
+func packName(_ name: String, queryBuilder: QueryBuilder) -> String {
     var result = name
-    if result.contains(" ") && !result.hasPrefix("\"") {
-        result = "\"" + result + "\""
+    let identQuoteChar = queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.identifierQuoteCharacter.rawValue]
+    if result.contains(" ") && !result.hasPrefix(identQuoteChar) {
+        result = identQuoteChar + result + identQuoteChar
     }
    return result
 }


### PR DESCRIPTION
MySQL uses backquotes instead of double quotes to quote identifiers with spaces or special characters. This change makes this character customizable using QuerySubstitutionNames keeping the default the same as it currently is hardcoded to (double quotes).