### PR TITLE
Avoid poolLock.wait deadlock

### DIFF
--- a/Sources/SwiftKuery/ConnectionPool.swift
+++ b/Sources/SwiftKuery/ConnectionPool.swift
@@ -129,7 +129,8 @@ public class ConnectionPool {
         if (pool.count == 0 && capacity < limit) {
             capacity += 1
             if let newItem = generator() {
-                give(newItem)
+                pool.append(newItem)
+                semaphore.signal()
             }
         }
         unlockPoolLock()


### PR DESCRIPTION
As we already locked/decremented `poolLock` in line 121, calling `lockPoolLock()` again by calling `give(_ item: Connection)` always deadlocks. So we need to either change `poolLock` to a re-entrant lock like `NSRecursiveLock` or do the change in this PR.