### PR TITLE
Add a SelectConstants type

### DIFF
--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -31,7 +31,7 @@ public struct Insert: Query {
     public private (set) var suffix: QuerySuffixProtocol?
     
     /// The select query that retrieves the rows to insert (for INSERT INTO SELECT).
-    public private (set) var query: Select?
+    public private (set) var query: SelectQuery?
     
     /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
     public private (set) var with: [AuxiliaryTable]?
@@ -115,12 +115,12 @@ public struct Insert: Query {
     /// - Parameter into: The table to insert rows.
     /// - Parameter columns: An optional array of columns to insert. If nil, values of all the columns have to be provided.
     /// - Parameter query: The select query that retrieves the rows to insert.
-    public init(into table: Table, columns: [Column]?=nil, _ query: Select) {
+    public init(into table: Table, columns: [Column]?=nil, _ query: SelectQuery) {
         self.columns = columns
         self.table = table
         self.query = query
-        if let tableColumns = self.columns, let selectColumns = query.fields,
-            tableColumns.count != selectColumns.count {
+        if let tableColumns = self.columns, let selectColumnCount = query.columnCount,
+            tableColumns.count != selectColumnCount {
             syntaxError = "Number of columns in Select doesn't match column count. "
         }
     }

--- a/Sources/SwiftKuery/Query.swift
+++ b/Sources/SwiftKuery/Query.swift
@@ -38,3 +38,7 @@ public extension Query {
         connection.execute(query: self, parameters: parameters, onCompletion: onCompletion)
     }
 }
+
+public protocol SelectQuery: Query {
+    var columnCount: Int? { get }
+}

--- a/Sources/SwiftKuery/Select.swift
+++ b/Sources/SwiftKuery/Select.swift
@@ -17,7 +17,7 @@
 // Mark: Select
 
 /// The SQL SELECT statement.
-public struct Select: Query {
+public struct Select: SelectQuery {
     /// An array of `Field` elements to select.
     public let fields: [Field]?
     
@@ -189,6 +189,10 @@ public struct Select: Query {
 
         result = Utils.updateParameterNumbers(query: result, queryBuilder: queryBuilder)
         return result
+    }
+
+    public var columnCount: Int? {
+        return self.fields?.count
     }
 
     /// Create a SELECT DISTINCT query.

--- a/Sources/SwiftKuery/SelectConstants.swift
+++ b/Sources/SwiftKuery/SelectConstants.swift
@@ -1,0 +1,114 @@
+//
+//  SelectConstants.swift
+//  ScribbleServer
+//
+//  Created by Bridger Maxwell on 7/8/17.
+//
+
+import Foundation
+
+// Mark: SelectConstants
+
+public struct ConstantField: Field {
+    /// The alias of the field.
+    public var alias: String?
+
+    /// Build the query component using `QueryBuilder`.
+    ///
+    /// - Parameter queryBuilder: The QueryBuilder to use.
+    /// - Returns: A String representation of the query component.
+    /// - Throws: QueryError.syntaxError if query build fails.
+    public func build(queryBuilder: QueryBuilder) throws -> String {
+        switch value {
+        case let val as String:
+            return "'\(val)'"
+        case let value as Date:
+            return "'\(String(describing: value))'"
+        case let constantFunction as ConstantFunction:
+            switch constantFunction {
+            case .now:
+                return queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.now.rawValue]
+            }
+        default:
+            return String(describing: value)
+        }
+    }
+
+    let value: Any
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public enum ConstantFunction {
+        case now()
+    }
+}
+
+/// The SQL SELECT statement with constants instead of a table.
+public struct SelectConstants: SelectQuery {
+    /// An array of constants to select.
+    public let values: [ConstantField]
+
+    /// The SQL WHERE clause containing the filter for rows to retrieve.
+    /// Could be represented with a `Filter` clause or a `String` containing raw SQL.
+    public private (set) var whereClause: QueryFilterProtocol?
+
+    private var syntaxError = ""
+
+    /// Initialize an instance of Select.
+    ///
+    /// - Parameter values: A list of `ConstantField` elements to select.
+    public init(_ values: ConstantField...) {
+        self.values = values
+    }
+
+    public init(_ values: Any...) {
+        self.values = values.map({ ConstantField($0) })
+    }
+
+    /// Initialize an instance of Select.
+    ///
+    /// - Parameter values: An array of `ConstantField` elements to select.
+    public init(values: [ConstantField]) {
+        self.values = values
+    }
+
+    /// Build the query using `QueryBuilder`.
+    ///
+    /// - Parameter queryBuilder: The QueryBuilder to use.
+    /// - Returns: A String representation of the query.
+    /// - Throws: QueryError.syntaxError if query build fails.
+    public func build(queryBuilder: QueryBuilder) throws -> String {
+        var result = ""
+
+        result += "SELECT "
+
+        result += try "\(values.map { try $0.build(queryBuilder: queryBuilder) }.joined(separator: ", "))"
+
+        if let whereClause = whereClause {
+            result += try " WHERE " + whereClause.build(queryBuilder: queryBuilder)
+        }
+
+        result = Utils.updateParameterNumbers(query: result, queryBuilder: queryBuilder)
+        return result
+    }
+
+    /// Add an SQL WHERE clause to the select statement.
+    ///
+    /// - Parameter conditions: The `Filter` clause or a `String` containing SQL WHERE clause to apply.
+    /// - Returns: A new instance of Select with the WHERE clause.
+    public func `where`(_ conditions: QueryFilterProtocol) -> SelectConstants {
+        var new = self
+        if whereClause != nil {
+            new.syntaxError += "Multiple where clauses. "
+        } else {
+            new.whereClause = conditions
+        }
+        return new
+    }
+
+    public var columnCount: Int? {
+        return self.values.count
+    }
+}
+


### PR DESCRIPTION
This is a draft pull request for this feature. If the general idea is accepted I'll clean up the formatting, add comments, etc before it would be merged.

This is to add a new type of Select which just returns constant data. It is useful for doing an insert if a value doesn't already exist. For example:

```
INSERT INTO document (documentId, created)
       SELECT 'E82091B4', NOW()
       WHERE NOT EXISTS (SELECT documentId FROM documents WHERE documentId='E82091B4');
```

would be expressed as:

```
let selectExisting = Select(documents.documentId, from: documents).where(documents.documentId == documentId)
let valuesAsSelectNotExists = SelectConstants(documentId, ConstantField.ConstantFunction.now()).where(notExists(selectExisting))
let inertDocumentIfNecessary = Insert(into: documents, columns: [documents.documentId, documents.creationDate], valuesAsSelectNotExists)
```

If the high level idea of this PR is accepted I'll do the following cleanups:
- Put ConstantField into its own file
- Remove ScalarColumnExpression's now() function and instead only have now() as a ConstantField
- Put in comments for new functions
- Should SelectQuery declaration be moved to its own file?