### PR TITLE
Fix crash when deallocating connection pool

### DIFF
--- a/Sources/SwiftKuery/ConnectionPool.swift
+++ b/Sources/SwiftKuery/ConnectionPool.swift
@@ -120,6 +120,7 @@ public class ConnectionPool {
         // We have permission to take an item - do so in a thread-safe way
         lockPoolLock()
         if (pool.count < 1) {
+            semaphore.signal()
             unlockPoolLock()
             return nil
         }


### PR DESCRIPTION
In case no connection can be established to the database we need to
make sure to signal the connection pool semaphore when retuning nil in
take(), otherwise libdispatch will complain (and crash the application)
when deallocating the connection pool (including the semaphore).