### PR TITLE
Added function to get last inserted ID

### DIFF
--- a/Sources/SwiftKuery/Connection.swift
+++ b/Sources/SwiftKuery/Connection.swift
@@ -154,7 +154,7 @@ public protocol Connection {
     func release(savepoint: String, onCompletion: @escaping ((QueryResult) -> ()))
     
     /// Get the ID of the last insert
-    func lastInsertID() throws -> Int32
+    func lastInsertID(onCompletion: @escaping ((QueryResult) -> ()))
 }
 
 public extension Connection {

--- a/Sources/SwiftKuery/Connection.swift
+++ b/Sources/SwiftKuery/Connection.swift
@@ -151,7 +151,10 @@ public protocol Connection {
     ///
     /// - Parameter savepoint: The name of the savepoint to release.
     /// - Parameter onCompletion: The function to be called when the execution of release savepoint command has completed.
-    func release(savepoint: String, onCompletion: @escaping ((QueryResult) -> ()))    
+    func release(savepoint: String, onCompletion: @escaping ((QueryResult) -> ()))
+    
+    /// Get the ID of the last insert
+    func lastInsertID() throws -> Int32
 }
 
 public extension Connection {

--- a/Sources/SwiftKuery/ConnectionPoolConnection.swift
+++ b/Sources/SwiftKuery/ConnectionPoolConnection.swift
@@ -303,11 +303,13 @@ public class ConnectionPoolConnection: Connection {
     }
     
     /// Get the ID of the last insert
-    public func lastInsertID() throws -> Int32 {
-        if let connection = self.connection {
-            return try connection.lastInsertID()
-        } else {
-            throw QueryError.connection("No connection to the database")
+    public func lastInsertID(onCompletion: @escaping ((QueryResult) -> ())) {
+        guard let connection = connection else {
+            onCompletion(.error(QueryError.connection("No connection to the database")))
+            return
         }
+        connection.lastInsertID(onCompletion: { (result) in
+            onCompletion(result)
+        })
     }
 }

--- a/Sources/SwiftKuery/ConnectionPoolConnection.swift
+++ b/Sources/SwiftKuery/ConnectionPoolConnection.swift
@@ -301,4 +301,13 @@ public class ConnectionPoolConnection: Connection {
         }
         connection.release(savepoint: savepoint, onCompletion: onCompletion)
     }
+    
+    /// Get the ID of the last insert
+    public func lastInsertID() throws -> Int32 {
+        if let connection = self.connection {
+            return try connection.lastInsertID()
+        } else {
+            throw QueryError.connection("No connection to the database")
+        }
+    }
 }

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -123,6 +123,10 @@ class TestConnection: Connection {
     func execute(preparedStatement: PreparedStatement, parameters: [String:Any?], onCompletion: @escaping ((QueryResult) -> ())) {}
     
     func release(preparedStatement: PreparedStatement, onCompletion: @escaping ((QueryResult) -> ())) {}
+    
+    func lastInsertID() throws -> Int32 {
+        return 1
+    }
 }
 
 class TestResultFetcher: ResultFetcher {

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -124,8 +124,8 @@ class TestConnection: Connection {
     
     func release(preparedStatement: PreparedStatement, onCompletion: @escaping ((QueryResult) -> ())) {}
     
-    func lastInsertID() throws -> Int32 {
-        return 1
+    public func lastInsertID(onCompletion: @escaping ((QueryResult) -> ())) {
+        onCompletion(.success(Int32(1)))
     }
 }
 

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -77,6 +77,13 @@ class TestInsert: XCTestCase {
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO tableInsert (a) SELECT tableInsert2.a FROM tableInsert2 RETURNING a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
+        do {
+            let id = try connection.lastInsertID()
+            XCTAssertEqual(id, 1)
+        } catch {
+            XCTFail()
+        }
     }
     
     func testInsertWith() {

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -78,12 +78,17 @@ class TestInsert: XCTestCase {
         query = "INSERT INTO tableInsert (a) SELECT tableInsert2.a FROM tableInsert2 RETURNING a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
-        do {
-            let id = try connection.lastInsertID()
-            XCTAssertEqual(id, 1)
-        } catch {
-            XCTFail()
-        }
+        connection.lastInsertID(onCompletion: { (result) in
+            XCTAssertNil(result.asError)
+            XCTAssertNil(result.asRows)
+            XCTAssertNil(result.asResultSet)
+            
+            if let id = result.asValue as? Int32 {
+                XCTAssertEqual(id, 1)
+            } else {
+                XCTFail()
+            }
+        })
     }
     
     func testInsertWith() {


### PR DESCRIPTION
## Description
A simple function has been added to the Connection protocol that allows for the easy retrieval of the last inserted ID.

Because this modifies the Connection protocol, a major version bump is required (e.g. to 1.1).


## Motivation and Context
It's often extremely useful to know the ID of a recently-inserted object, e.g. for foreign keys

## How Has This Been Tested?
The pre-existing test suite was run, and all tests passed.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.