### PR TITLE
Add binary and varbinary SQLDataType

### DIFF
--- a/Sources/SwiftKuery/SQLDataType.swift
+++ b/Sources/SwiftKuery/SQLDataType.swift
@@ -80,6 +80,28 @@ public struct Timestamp: SQLDataType {
     }
 }
 
+/// SQL binary type.
+public struct Binary: SQLDataType {
+    /// Return database specific representation of the binary type using `QueryBuilder`.
+    ///
+    /// - Parameter queryBuilder: The QueryBuilder to use.
+    /// - Returns: A String representation of the type.
+    public static func create(queryBuilder: QueryBuilder) -> String {
+        return "binary"
+    }
+}
+
+/// SQL varbinary type.
+public struct Varbinary: SQLDataType {
+    /// Return database specific representation of the varbinary type using `QueryBuilder`.
+    ///
+    /// - Parameter queryBuilder: The QueryBuilder to use.
+    /// - Returns: A String representation of the type.
+    public static func create(queryBuilder: QueryBuilder) -> String {
+        return "varbinary"
+    }
+}
+
 extension Int16: SQLDataType {
     /// Return database specific representation of the int16 type using `QueryBuilder`.
     ///


### PR DESCRIPTION
Faster comparison and sorting of fields using binary and varbinary types in MySQL comparing to char and varchar. In case of binary/varbinary, comparison and sorting is based on the numeric values of the bytes in the values.