### PR TITLE
Add case protection for postgreSQL

### DIFF
--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -90,11 +90,11 @@ public class Column: Field, IndexColumn {
     /// - Returns: A String representation of the column.
     /// - Throws: QueryError.syntaxError if query build fails.
     public func build(queryBuilder: QueryBuilder) throws -> String {
-        let tableName = Utils.packName(table.nameInQuery, queryBuilder: queryBuilder)
+        let tableName = table.nameInQuery
         if tableName == "" {
             throw QueryError.syntaxError("Table name not set. ")
         }
-        var result = tableName + "." + Utils.packName(name, queryBuilder: queryBuilder)
+        var result = tableName.contains(" ") ? tableName + "." + Utils.packName(name, queryBuilder: queryBuilder) : Utils.packName(tableName + "." + name, queryBuilder: queryBuilder)
         if let alias = alias {
             result += " AS " + Utils.packName(alias, queryBuilder: queryBuilder)
         }
@@ -165,7 +165,7 @@ public class Column: Field, IndexColumn {
             result += " DEFAULT " + Utils.packType(defaultValue)
         }
         if let checkExpression = checkExpression {
-            result += " CHECK (" + checkExpression + ")"
+            result += checkExpression.contains(name) ? " CHECK (" + checkExpression.replacingOccurrences(of: name, with: "\"\(name)\"") + ")" : " CHECK (" + checkExpression + ")"
         }
         if let collate = collate {
             result += " COLLATE \"" + collate + "\""

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -153,7 +153,7 @@ public struct Insert: Query {
         
         result += try table.build(queryBuilder: queryBuilder) + " "
         if let columns = columns, columns.count != 0 {
-            result += "(\(columns.map { $0.name }.joined(separator: ", "))) "
+            result += "(\(columns.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", "))) "
         }
         if let values = values {
             result += "VALUES ("

--- a/Sources/SwiftKuery/RawField.swift
+++ b/Sources/SwiftKuery/RawField.swift
@@ -38,7 +38,7 @@ public struct RawField: Field {
     public func build(queryBuilder: QueryBuilder) -> String {
         var result = field
         if let alias = alias {
-            result += " AS " + alias
+            result += " AS " + Utils.packName(alias, queryBuilder: queryBuilder)
         }
         return result
     }

--- a/Sources/SwiftKuery/Select.swift
+++ b/Sources/SwiftKuery/Select.swift
@@ -149,7 +149,7 @@ public struct Select: Query {
             }
             
             if let using = item.using {
-                result += " USING (" + using.map { $0.name }.joined(separator: ", ") + ")"
+                result += " USING (" + using.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ") + ")"
             }
         }
         

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -51,7 +51,7 @@ struct Utils {
     static func packName(_ name: String, queryBuilder: QueryBuilder) -> String {
         var result = name
         let identifierQuoteCharacter = queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.identifierQuoteCharacter.rawValue]
-        if result.contains(" ") && !result.hasPrefix(identifierQuoteCharacter) {
+        if !result.hasPrefix(identifierQuoteCharacter) {
             result = identifierQuoteCharacter + result + identifierQuoteCharacter
         }
         return result

--- a/Tests/SwiftKueryTests/TestAggregateFunctions.swift
+++ b/Tests/SwiftKueryTests/TestAggregateFunctions.swift
@@ -46,90 +46,90 @@ class TestAggregateFunctions: XCTestCase {
             .group(by: t.a)
             .having(avg(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(max(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(min(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(sum(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(last(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(first(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(count(t.b) > 3)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING COUNT(table.b) > 3"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING COUNT(\"table.b\") > 3"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(countDistinct(t.b) != 0)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING COUNT(DISTINCT(table.b)) <> 0"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING COUNT(DISTINCT(\"table.b\")) <> 0"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(ucase(sum(t.b)) <= -1)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING UCASE(SUM(table.b)) <= -1"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING UCASE(SUM(\"table.b\")) <= -1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(lcase(sum(t.b)) <= -1)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING LCASE(SUM(table.b)) <= -1"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LCASE(SUM(\"table.b\")) <= -1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(len(sum(t.b)) <= -1)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING LEN(SUM(table.b)) <= -1"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LEN(SUM(\"table.b\")) <= -1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(round(sum(t.b), to: 2) >= 9.08)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING ROUND(SUM(table.b), 2) >= 9.08"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ROUND(SUM(\"table.b\"), 2) >= 9.08"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(mid(sum(t.b), start: 3, length: 6) <= -1)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table.a FROM table GROUP BY table.a HAVING MID(SUM(table.b), 3, 6) <= -1"
+        query = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MID(SUM(\"table.b\"), 3, 6) <= -1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
   }
 }

--- a/Tests/SwiftKueryTests/TestAlias.swift
+++ b/Tests/SwiftKueryTests/TestAlias.swift
@@ -39,18 +39,18 @@ class TestAlias: XCTestCase {
         
         var s = Select(t.a.as("\"fruit name\""), t.b.as("number"), from: t)
         var kuery = connection.descriptionOf(query: s)
-        var query = "SELECT tableAlias.a AS \"fruit name\", tableAlias.b AS number FROM tableAlias"
+        var query = "SELECT \"tableAlias.a\" AS \"fruit name\", \"tableAlias.b\" AS \"number\" FROM \"tableAlias\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t.as("new"))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableAlias AS new"
+        query = "SELECT * FROM \"tableAlias\" AS \"new\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         let t2 = t.as("\"t 2\"")
         s = Select(t2.a, from: t2)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT \"t 2\".a FROM tableAlias AS \"t 2\""
+        query = "SELECT \"t 2\".\"a\" FROM \"tableAlias\" AS \"t 2\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestFilterAndHaving.swift
+++ b/Tests/SwiftKueryTests/TestFilterAndHaving.swift
@@ -55,8 +55,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) == "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) = 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) = 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") = 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") = 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -64,8 +64,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" == lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' = LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' = LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' = LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' = LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -73,8 +73,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -82,8 +82,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -91,8 +91,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) == round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) = ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) = ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") = ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") = ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -100,8 +100,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -109,8 +109,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -118,8 +118,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -127,8 +127,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) == 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) = 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) = 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") = 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") = 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -136,8 +136,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 == len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 = LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 = LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 = LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 = LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -145,8 +145,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b == 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b = 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b = 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" = 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" = 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -154,8 +154,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -163,8 +163,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) == Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) = 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) = 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") = 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") = 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -172,8 +172,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) == len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 = LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 = LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 = LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 = LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -181,8 +181,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b == Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b = 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b = 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" = 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" = 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -190,8 +190,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -199,8 +199,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) == 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) = 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) = 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") = 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") = 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -208,8 +208,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 == len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 = LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 = LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 = LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 = LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -217,8 +217,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b == 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b = 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b = 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" = 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" = 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -226,8 +226,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -235,8 +235,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) == Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) = @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) = @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") = @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") = @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -244,8 +244,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() == len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 = LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 = LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 = LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 = LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -253,8 +253,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -262,8 +262,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -271,8 +271,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -280,8 +280,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -289,8 +289,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -298,8 +298,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -307,8 +307,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -316,8 +316,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -325,8 +325,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -334,8 +334,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() == Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() = '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() = '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() = '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() = '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -343,8 +343,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) == now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' = NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' = NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' = NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' = NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -352,8 +352,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -361,8 +361,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -370,8 +370,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) == "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) = 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) = 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") = 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") = 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -379,8 +379,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" == last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' = LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' = LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' = LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' = LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -388,8 +388,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -397,8 +397,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -406,8 +406,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) == last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) = LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) = LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") = LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") = LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -415,8 +415,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -424,8 +424,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -433,8 +433,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -442,8 +442,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) == 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) = 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) = 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") = 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") = 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -451,8 +451,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 == sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 = SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 = SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 = SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 = SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -460,8 +460,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b == 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b = 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b = 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" = 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" = 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -469,8 +469,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -478,8 +478,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) == Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) = 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) = 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") = 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") = 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -487,8 +487,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) == max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 = MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 = MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 = MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 = MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -496,8 +496,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b == Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b = 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b = 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" = 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" = 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -505,8 +505,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -514,8 +514,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) == 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) = 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) = 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") = 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") = 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -523,8 +523,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 == max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 = MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 = MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 = MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 = MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -532,8 +532,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b == 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b = 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b = 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" = 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" = 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -541,8 +541,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 == t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 = table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 = table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 = \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 = \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -550,8 +550,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) == Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) = @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) = @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") = @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") = @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -559,8 +559,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() == min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 = MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 = MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 = MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 = MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -568,8 +568,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -577,8 +577,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -586,8 +586,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -595,8 +595,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -604,8 +604,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -613,8 +613,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -622,8 +622,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -631,8 +631,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -640,8 +640,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() == Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 = (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 = (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 = (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 = (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -649,8 +649,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) == Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) = '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) = '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") = '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") = '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -658,8 +658,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) == last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' = LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' = LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' = LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' = LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -667,8 +667,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -676,8 +676,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -685,8 +685,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) >= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) >= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) >= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") >= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") >= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -694,8 +694,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" >= lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' >= LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' >= LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' >= LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' >= LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -703,8 +703,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -712,8 +712,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -721,8 +721,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) >= round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) >= ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) >= ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") >= ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") >= ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -730,8 +730,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -739,8 +739,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -748,8 +748,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -757,8 +757,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) >= 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) >= 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) >= 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") >= 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") >= 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -766,8 +766,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 >= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 >= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 >= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 >= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 >= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -775,8 +775,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b >= 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b >= 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b >= 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" >= 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" >= 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -784,8 +784,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -793,8 +793,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) >= Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) >= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) >= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") >= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") >= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -802,8 +802,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) >= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 >= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 >= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 >= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 >= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -811,8 +811,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b >= Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b >= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b >= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" >= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" >= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -820,8 +820,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -829,8 +829,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) >= 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) >= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) >= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") >= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") >= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -838,8 +838,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 >= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 >= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 >= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 >= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 >= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -847,8 +847,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b >= 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b >= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b >= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" >= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" >= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -856,8 +856,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -865,8 +865,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) >= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) >= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) >= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") >= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") >= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -874,8 +874,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() >= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 >= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 >= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 >= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 >= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -883,8 +883,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -892,8 +892,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -901,8 +901,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -910,8 +910,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -919,8 +919,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -928,8 +928,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -937,8 +937,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -946,8 +946,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -955,8 +955,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -964,8 +964,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() >= Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() >= '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() >= '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() >= '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() >= '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -973,8 +973,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) >= now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' >= NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' >= NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' >= NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' >= NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -982,8 +982,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a >= Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -991,8 +991,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1000,8 +1000,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) >= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) >= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) >= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") >= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") >= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1009,8 +1009,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" >= last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' >= LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' >= LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' >= LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' >= LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1018,8 +1018,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1027,8 +1027,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1036,8 +1036,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) >= last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) >= LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) >= LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") >= LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") >= LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1045,8 +1045,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1054,8 +1054,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1063,8 +1063,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1072,8 +1072,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) >= 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) >= 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) >= 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") >= 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") >= 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1081,8 +1081,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 >= sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 >= SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 >= SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 >= SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 >= SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1090,8 +1090,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b >= 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b >= 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b >= 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" >= 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" >= 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1099,8 +1099,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1108,8 +1108,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) >= Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) >= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) >= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") >= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") >= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1117,8 +1117,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) >= max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 >= MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 >= MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 >= MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 >= MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1126,8 +1126,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b >= Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b >= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b >= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" >= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" >= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1135,8 +1135,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1144,8 +1144,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) >= 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) >= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) >= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") >= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") >= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1153,8 +1153,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 >= max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 >= MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 >= MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 >= MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 >= MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1162,8 +1162,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b >= 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b >= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b >= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" >= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" >= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1171,8 +1171,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 >= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 >= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 >= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 >= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 >= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1180,8 +1180,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) >= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) >= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) >= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") >= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") >= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1189,8 +1189,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() >= min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 >= MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 >= MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 >= MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 >= MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1198,8 +1198,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1207,8 +1207,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1216,8 +1216,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1225,8 +1225,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1234,8 +1234,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1243,8 +1243,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1252,8 +1252,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1261,8 +1261,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1270,8 +1270,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() >= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 >= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 >= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 >= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 >= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1279,8 +1279,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) >= Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) >= '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) >= '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") >= '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") >= '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1288,8 +1288,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) >= last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' >= LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' >= LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' >= LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' >= LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1297,8 +1297,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a >= Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1306,8 +1306,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) >= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' >= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' >= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' >= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' >= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1315,8 +1315,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) > "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) > 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) > 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") > 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") > 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1324,8 +1324,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" > lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' > LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' > LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' > LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' > LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1333,8 +1333,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1342,8 +1342,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1351,8 +1351,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) > round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) > ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) > ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") > ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") > ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1360,8 +1360,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1369,8 +1369,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1378,8 +1378,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1387,8 +1387,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) > 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) > 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) > 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") > 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") > 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1396,8 +1396,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 > len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 > LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 > LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 > LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 > LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1405,8 +1405,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b > 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b > 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b > 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" > 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" > 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1414,8 +1414,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1423,8 +1423,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) > Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) > 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) > 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") > 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") > 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1432,8 +1432,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) > len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 > LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 > LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 > LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 > LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1441,8 +1441,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b > Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b > 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b > 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" > 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" > 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1450,8 +1450,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1459,8 +1459,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) > 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) > 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) > 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") > 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") > 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1468,8 +1468,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 > len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 > LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 > LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 > LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 > LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1477,8 +1477,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b > 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b > 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b > 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" > 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" > 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1486,8 +1486,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1495,8 +1495,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) > Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) > @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) > @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") > @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") > @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1504,8 +1504,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() > len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 > LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 > LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 > LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 > LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1513,8 +1513,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1522,8 +1522,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1531,8 +1531,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1540,8 +1540,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1549,8 +1549,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1558,8 +1558,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1567,8 +1567,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1576,8 +1576,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1585,8 +1585,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1594,8 +1594,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() > Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() > '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() > '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() > '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() > '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1603,8 +1603,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) > now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' > NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' > NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' > NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' > NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1612,8 +1612,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a > Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1621,8 +1621,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1630,8 +1630,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) > "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) > 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) > 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") > 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") > 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1639,8 +1639,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" > last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' > LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' > LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' > LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' > LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1648,8 +1648,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1657,8 +1657,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1666,8 +1666,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) > last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) > LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) > LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") > LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") > LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1675,8 +1675,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1684,8 +1684,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1693,8 +1693,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1702,8 +1702,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) > 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) > 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) > 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") > 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") > 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1711,8 +1711,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 > sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 > SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 > SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 > SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 > SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1720,8 +1720,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b > 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b > 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b > 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" > 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" > 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1729,8 +1729,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1738,8 +1738,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) > Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) > 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) > 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") > 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") > 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1747,8 +1747,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) > max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 > MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 > MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 > MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 > MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1756,8 +1756,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b > Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b > 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b > 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" > 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" > 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1765,8 +1765,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1774,8 +1774,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) > 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) > 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) > 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") > 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") > 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1783,8 +1783,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 > max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 > MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 > MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 > MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 > MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1792,8 +1792,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b > 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b > 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b > 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" > 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" > 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1801,8 +1801,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 > t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 > table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 > table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 > \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 > \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1810,8 +1810,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) > Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) > @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) > @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") > @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") > @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1819,8 +1819,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() > min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 > MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 > MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 > MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 > MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1828,8 +1828,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1837,8 +1837,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1846,8 +1846,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1855,8 +1855,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1864,8 +1864,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1873,8 +1873,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1882,8 +1882,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1891,8 +1891,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1900,8 +1900,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() > Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 > (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 > (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 > (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 > (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1909,8 +1909,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) > Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) > '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) > '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") > '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") > '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1918,8 +1918,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) > last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' > LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' > LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' > LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' > LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1927,8 +1927,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a > Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1936,8 +1936,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) > t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' > table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' > table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' > \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' > \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1945,8 +1945,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) <= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) <= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) <= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") <= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") <= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1954,8 +1954,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" <= lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <= LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <= LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <= LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <= LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1963,8 +1963,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1972,8 +1972,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1981,8 +1981,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) <= round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <= ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <= ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <= ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <= ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1990,8 +1990,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1999,8 +1999,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2008,8 +2008,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2017,8 +2017,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) <= 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <= 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <= 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <= 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <= 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2026,8 +2026,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 <= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 <= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 <= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 <= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 <= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2035,8 +2035,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b <= 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <= 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <= 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <= 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <= 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2044,8 +2044,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2053,8 +2053,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) <= Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2062,8 +2062,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) <= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 <= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 <= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 <= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 <= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2071,8 +2071,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b <= Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2080,8 +2080,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2089,8 +2089,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) <= 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2098,8 +2098,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 <= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 <= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 <= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 <= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 <= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2107,8 +2107,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b <= 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2116,8 +2116,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2125,8 +2125,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) <= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2134,8 +2134,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() <= len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <= LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <= LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <= LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <= LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2143,8 +2143,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2152,8 +2152,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2161,8 +2161,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2170,8 +2170,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2179,8 +2179,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2188,8 +2188,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2197,8 +2197,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2206,8 +2206,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2215,8 +2215,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2224,8 +2224,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() <= Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() <= '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() <= '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() <= '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() <= '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2233,8 +2233,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) <= now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' <= NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' <= NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' <= NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' <= NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2242,8 +2242,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a <= Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2251,8 +2251,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2260,8 +2260,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) <= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) <= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) <= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") <= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") <= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2269,8 +2269,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" <= last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <= LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <= LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <= LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <= LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2278,8 +2278,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2287,8 +2287,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2296,8 +2296,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) <= last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) <= LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) <= LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") <= LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") <= LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2305,8 +2305,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2314,8 +2314,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2323,8 +2323,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2332,8 +2332,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) <= 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) <= 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) <= 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") <= 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") <= 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2341,8 +2341,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 <= sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 <= SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 <= SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 <= SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 <= SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2350,8 +2350,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b <= 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <= 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <= 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <= 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <= 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2359,8 +2359,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2368,8 +2368,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) <= Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) <= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) <= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") <= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") <= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2377,8 +2377,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) <= max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 <= MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 <= MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 <= MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 <= MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2386,8 +2386,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b <= Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2395,8 +2395,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2404,8 +2404,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) <= 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) <= 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) <= 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") <= 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") <= 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2413,8 +2413,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 <= max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 <= MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 <= MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 <= MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 <= MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2422,8 +2422,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b <= 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <= 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <= 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <= 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <= 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2431,8 +2431,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 <= t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 <= table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 <= table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 <= \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 <= \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2440,8 +2440,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) <= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) <= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) <= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") <= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") <= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2449,8 +2449,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() <= min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <= MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <= MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <= MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <= MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2458,8 +2458,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2467,8 +2467,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2476,8 +2476,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2485,8 +2485,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2494,8 +2494,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2503,8 +2503,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2512,8 +2512,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2521,8 +2521,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2530,8 +2530,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() <= Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <= (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <= (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <= (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <= (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2539,8 +2539,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) <= Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) <= '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) <= '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") <= '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") <= '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2548,8 +2548,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) <= last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' <= LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' <= LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' <= LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' <= LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2557,8 +2557,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a <= Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2566,8 +2566,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) <= t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' <= table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' <= table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' <= \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' <= \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2575,8 +2575,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) < "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) < 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) < 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") < 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") < 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2584,8 +2584,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" < lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' < LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' < LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' < LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' < LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2593,8 +2593,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2602,8 +2602,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2611,8 +2611,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) < round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) < ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) < ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") < ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") < ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2620,8 +2620,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2629,8 +2629,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2638,8 +2638,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2647,8 +2647,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) < 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) < 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) < 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") < 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") < 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2656,8 +2656,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 < len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 < LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 < LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 < LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 < LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2665,8 +2665,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b < 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b < 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b < 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" < 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" < 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2674,8 +2674,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2683,8 +2683,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) < Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) < 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) < 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") < 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") < 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2692,8 +2692,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) < len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 < LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 < LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 < LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 < LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2701,8 +2701,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b < Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b < 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b < 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" < 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" < 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2710,8 +2710,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2719,8 +2719,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) < 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) < 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) < 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") < 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") < 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2728,8 +2728,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 < len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 < LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 < LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 < LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 < LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2737,8 +2737,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b < 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b < 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b < 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" < 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" < 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2746,8 +2746,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2755,8 +2755,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) < Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) < @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) < @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") < @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") < @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2764,8 +2764,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() < len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 < LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 < LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 < LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 < LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2773,8 +2773,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2782,8 +2782,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2791,8 +2791,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2800,8 +2800,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2809,8 +2809,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2818,8 +2818,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2827,8 +2827,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2836,8 +2836,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2845,8 +2845,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2854,8 +2854,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() < Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() < '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() < '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() < '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() < '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2863,8 +2863,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) < now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' < NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' < NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' < NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' < NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2872,8 +2872,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a < Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2881,8 +2881,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2890,8 +2890,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) < "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) < 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) < 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") < 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") < 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2899,8 +2899,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" < last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' < LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' < LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' < LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' < LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2908,8 +2908,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2917,8 +2917,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2926,8 +2926,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) < last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) < LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) < LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") < LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") < LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2935,8 +2935,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2944,8 +2944,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2953,8 +2953,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2962,8 +2962,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) < 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) < 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) < 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") < 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") < 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2971,8 +2971,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 < sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 < SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 < SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 < SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 < SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2980,8 +2980,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b < 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b < 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b < 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" < 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" < 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2989,8 +2989,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2998,8 +2998,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) < Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) < 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) < 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") < 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") < 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3007,8 +3007,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) < max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 < MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 < MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 < MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 < MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3016,8 +3016,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b < Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b < 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b < 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" < 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" < 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3025,8 +3025,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3034,8 +3034,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) < 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) < 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) < 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") < 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") < 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3043,8 +3043,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 < max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 < MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 < MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 < MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 < MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3052,8 +3052,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b < 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b < 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b < 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" < 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" < 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3061,8 +3061,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 < t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 < table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 < table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 < \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 < \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3070,8 +3070,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) < Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) < @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) < @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") < @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") < @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3079,8 +3079,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() < min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 < MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 < MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 < MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 < MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3088,8 +3088,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3097,8 +3097,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3106,8 +3106,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3115,8 +3115,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3124,8 +3124,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3133,8 +3133,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3142,8 +3142,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3151,8 +3151,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3160,8 +3160,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() < Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 < (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 < (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 < (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 < (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3169,8 +3169,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) < Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) < '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) < '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") < '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") < '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3178,8 +3178,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) < last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' < LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' < LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' < LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' < LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3187,8 +3187,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a < Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3196,8 +3196,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) < t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' < table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' < table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' < \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' < \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3205,8 +3205,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) != "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) <> 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) <> 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") <> 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") <> 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3214,8 +3214,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" != lcase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <> LCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <> LCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <> LCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <> LCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3223,8 +3223,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3232,8 +3232,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3241,8 +3241,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) != round(t.b, to: 2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <> ROUND(table.b, 2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <> ROUND(table.b, 2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <> ROUND(\"table.b\", 2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <> ROUND(\"table.b\", 2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3250,8 +3250,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3259,8 +3259,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3268,8 +3268,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(mid(t.b, start: 3, length: 2) != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE MID(table.b, 3, 2) <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE MID(table.b, 3, 2) <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE MID(\"table.b\", 3, 2) <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE MID(\"table.b\", 3, 2) <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3277,8 +3277,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) != 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <> 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <> 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <> 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <> 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3286,8 +3286,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5 != len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5 <> LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5 <> LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5 <> LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5 <> LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3295,8 +3295,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b != 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <> 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <> 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <> 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <> 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3304,8 +3304,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18 != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3313,8 +3313,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) != Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <> 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <> 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <> 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <> 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3322,8 +3322,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(5.8) != len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 <> LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 <> LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 <> LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 <> LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3331,8 +3331,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b != Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <> 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <> 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <> 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <> 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3340,8 +3340,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(-18.789) != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3349,8 +3349,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) != 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <> 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <> 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <> 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <> 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3358,8 +3358,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(5.8 != len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 5.8 <> LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 5.8 <> LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 5.8 <> LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 5.8 <> LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3367,8 +3367,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.b != 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.b <> 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.b <> 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.b\" <> 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.b\" <> 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3376,8 +3376,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(-18.789 != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -18.789 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -18.789 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -18.789 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -18.789 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3385,8 +3385,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(len(t.a) != Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LEN(table.a) <> @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LEN(table.a) <> @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LEN(\"table.a\") <> @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LEN(\"table.a\") <> @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3394,8 +3394,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() != len(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <> LEN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <> LEN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <> LEN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <> LEN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3403,8 +3403,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3412,8 +3412,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3421,8 +3421,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3430,8 +3430,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where("banana" != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3439,8 +3439,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3448,8 +3448,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7 != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3457,8 +3457,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Float(7.2) != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3466,8 +3466,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(7.2 != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 7.2 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.2 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.2 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.2 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3475,8 +3475,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Parameter() != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3484,8 +3484,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(now() != Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE NOW() <> '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE NOW() <> '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE NOW() <> '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE NOW() <> '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3493,8 +3493,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 0) != now())
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' <> NOW() GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' <> NOW()"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' <> NOW() GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' <> NOW()"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3502,8 +3502,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3511,8 +3511,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000) != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3520,8 +3520,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) != "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) <> 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) <> 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") <> 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") <> 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3529,8 +3529,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" != last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <> LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <> LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <> LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <> LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3538,8 +3538,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != "banana")
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> 'banana' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> 'banana'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> 'banana' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> 'banana'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3547,8 +3547,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3556,8 +3556,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) != last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) <> LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) <> LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") <> LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") <> LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3565,8 +3565,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3574,8 +3574,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != last(t.b))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> LAST(table.b) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> LAST(table.b)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> LAST(\"table.b\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> LAST(\"table.b\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3583,8 +3583,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.b) != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.b) <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.b) <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.b\") <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.b\") <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3592,8 +3592,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) != 5)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) <> 5 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) <> 5"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") <> 5 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") <> 5"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3601,8 +3601,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5 != sum(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5 <> SUM(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5 <> SUM(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5 <> SUM(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5 <> SUM(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3610,8 +3610,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b != 178)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <> 178 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <> 178"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <> 178 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <> 178"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3619,8 +3619,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18 != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3628,8 +3628,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) != Float(5.8))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) <> 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) <> 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") <> 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") <> 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3637,8 +3637,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(5.8) != max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 <> MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 <> MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 <> MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 <> MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3646,8 +3646,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b != Float(178.9))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <> 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <> 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <> 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <> 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3655,8 +3655,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(-18.789) != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3664,8 +3664,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(max(t.a) != 5.8)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MAX(table.a) <> 5.8 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MAX(table.a) <> 5.8"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MAX(\"table.a\") <> 5.8 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MAX(\"table.a\") <> 5.8"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3673,8 +3673,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(5.8 != max(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 5.8 <> MAX(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 5.8 <> MAX(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 5.8 <> MAX(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 5.8 <> MAX(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3682,8 +3682,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.b != 178.9)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.b <> 178.9 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.b <> 178.9"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.b\" <> 178.9 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.b\" <> 178.9"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3691,8 +3691,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(-18.789 != t.b)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -18.789 <> table.b GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -18.789 <> table.b"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -18.789 <> \"table.b\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -18.789 <> \"table.b\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3700,8 +3700,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(min(t.a) != Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) <> @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) <> @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") <> @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") <> @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3709,8 +3709,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() != min(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <> MIN(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <> MIN(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <> MIN(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <> MIN(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3718,8 +3718,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != Parameter("param"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> @param GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> @param"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> @param GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> @param"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3727,8 +3727,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3736,8 +3736,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(avg(t.a) != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING AVG(table.a) <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING AVG(table.a) <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING AVG(\"table.a\") <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING AVG(\"table.a\") <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3745,8 +3745,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having("banana" != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3754,8 +3754,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3763,8 +3763,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7 != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3772,8 +3772,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Float(7.2) != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3781,8 +3781,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(7.2 != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 7.2 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.2 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.2 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.2 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3790,8 +3790,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Parameter() != Select(t2.c, from: t2))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <> (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <> (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <> (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <> (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3799,8 +3799,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(last(t.a) != Date(timeIntervalSince1970: 0))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) <> '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) <> '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") <> '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") <> '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3808,8 +3808,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 0) != last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' <> LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' <> LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' <> LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' <> LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3817,8 +3817,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != Date(timeIntervalSince1970: 10000))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> '1970-01-01 02:46:40 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> '1970-01-01 02:46:40 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> '1970-01-01 02:46:40 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> '1970-01-01 02:46:40 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3826,8 +3826,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000) != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3835,8 +3835,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) == true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) = true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) = true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") = true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") = true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3844,8 +3844,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(false == ucase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE false = UCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE false = UCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE false = UCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE false = UCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3853,8 +3853,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a == true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3862,8 +3862,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(true == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3871,8 +3871,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) == true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) = true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) = true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") = true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") = true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3880,8 +3880,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(false == last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING false = LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING false = LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING false = LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING false = LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3889,8 +3889,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a == true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3898,8 +3898,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(true == t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true = table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true = table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true = \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true = \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3907,8 +3907,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(lcase(t.a) != true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) <> true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) <> true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") <> true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") <> true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3916,8 +3916,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(false != ucase(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE false <> UCASE(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE false <> UCASE(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE false <> UCASE(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE false <> UCASE(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3925,8 +3925,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(t.a != true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3934,8 +3934,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .where(true != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3943,8 +3943,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(first(t.a) != true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) <> true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) <> true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") <> true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") <> true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3952,8 +3952,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(false != last(t.a))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING false <> LAST(table.a) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING false <> LAST(table.a)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING false <> LAST(\"table.a\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING false <> LAST(\"table.a\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3961,8 +3961,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(t.a != true)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> true GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> true"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> true GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> true"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -3970,8 +3970,8 @@ class TestFilterAndHaving: XCTestCase {
             .group(by: t.a)
             .having(true != t.a)
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true <> table.a GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true <> table.a"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true <> \"table.a\" GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true <> \"table.a\""
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
   }

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -47,35 +47,35 @@ class TestInsert: XCTestCase {
             
         var i = Insert(into: t, values: "apple", 10)
         var kuery = connection.descriptionOf(query: i)
-        var query = "INSERT INTO tableInsert VALUES ('apple', 10)"
+        var query = "INSERT INTO \"tableInsert\" VALUES ('apple', 10)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         i = Insert(into: t, values: ["apple", 10])
         kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO tableInsert VALUES ('apple', 10)"
+        query = "INSERT INTO \"tableInsert\" VALUES ('apple', 10)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         i = Insert(into: t, valueTuples: (t.a, "apricot"), (t.b, "3"))
         kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO tableInsert (a, b) VALUES ('apricot', '3')"
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('apricot', '3')"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         i = Insert(into: t, columns: [t.a, t.b], values: ["banana", 17])
             .suffix("RETURNING *")
         kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO tableInsert (a, b) VALUES ('banana', 17) RETURNING *"
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', 17) RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         i = Insert(into: t, rows: [["apple", 17], ["banana", -7], ["banana", 27]])
         kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO tableInsert VALUES ('apple', 17), ('banana', -7), ('banana', 27)"
+        query = "INSERT INTO \"tableInsert\" VALUES ('apple', 17), ('banana', -7), ('banana', 27)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         let t2 = MyTable2()
         i = Insert(into: t, columns: [t.a], Select(t2.a, from: t2))
             .suffix("RETURNING a")
         kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO tableInsert (a) SELECT tableInsert2.a FROM tableInsert2 RETURNING a"
+        query = "INSERT INTO \"tableInsert\" (\"a\") SELECT \"tableInsert2.a\" FROM \"tableInsert2\" RETURNING a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
     
@@ -95,7 +95,7 @@ class TestInsert: XCTestCase {
         var i = with(withTable,
                      Insert(into: t, columns: [t.a], insertSelect))
         let kuery = connection.descriptionOf(query: i)
-        let query = "WITH aux_table AS (SELECT tableInsert2.a AS c FROM tableInsert2) INSERT INTO tableInsert (a) SELECT aux_table.c FROM aux_table"
+        let query = "WITH \"aux_table\" AS (SELECT \"tableInsert2.a\" AS \"c\" FROM \"tableInsert2\") INSERT INTO \"tableInsert\" (\"a\") SELECT \"aux_table.c\" FROM \"aux_table\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         withTable = AuxTable()

--- a/Tests/SwiftKueryTests/TestJoin.swift
+++ b/Tests/SwiftKueryTests/TestJoin.swift
@@ -57,7 +57,7 @@ class TestJoin: XCTestCase {
             .join(myTable2)
             .on(myTable1.b == myTable2.b)
         var kuery = connection.descriptionOf(query: s)
-        var query = "SELECT * FROM table1Join JOIN table2Join ON table1Join.b = table2Join.b"
+        var query = "SELECT * FROM \"table1Join\" JOIN \"table2Join\" ON \"table1Join.b\" = \"table2Join.b\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: myTable1)
@@ -66,7 +66,7 @@ class TestJoin: XCTestCase {
             .rawJoin("NATURAL LEFT JOIN", myTable3)
             .on(myTable1.b == myTable3.b)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join NATURAL JOIN table2Join ON table1Join.b = table2Join.b NATURAL LEFT JOIN table3Join ON table1Join.b = table3Join.b"
+        query = "SELECT * FROM \"table1Join\" NATURAL JOIN \"table2Join\" ON \"table1Join.b\" = \"table2Join.b\" NATURAL LEFT JOIN \"table3Join\" ON \"table1Join.b\" = \"table3Join.b\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         let t1 = myTable1.as("t1")
@@ -76,7 +76,7 @@ class TestJoin: XCTestCase {
             .crossJoin(t2)
             .on(t1.b == t2.b)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join AS t1 CROSS JOIN table2Join AS t2 ON t1.b = t2.b"
+        query = "SELECT * FROM \"table1Join\" AS \"t1\" CROSS JOIN \"table2Join\" AS \"t2\" ON \"t1.b\" = \"t2.b\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t1)
@@ -85,7 +85,7 @@ class TestJoin: XCTestCase {
             .join(t3)
             .on(t1.b == t3.b)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join AS t1 JOIN table2Join AS t2 ON t1.b = t2.b JOIN table3Join AS t3 ON t1.b = t3.b"
+        query = "SELECT * FROM \"table1Join\" AS \"t1\" JOIN \"table2Join\" AS \"t2\" ON \"t1.b\" = \"t2.b\" JOIN \"table3Join\" AS \"t3\" ON \"t1.b\" = \"t3.b\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t1)
@@ -94,35 +94,35 @@ class TestJoin: XCTestCase {
             .rawJoin("NATURAL FULL JOIN", t3)
             .on(t1.b == t3.b)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join AS t1 JOIN table2Join AS t2 ON t1.b = t2.b NATURAL FULL JOIN table3Join AS t3 ON t1.b = t3.b"
+        query = "SELECT * FROM \"table1Join\" AS \"t1\" JOIN \"table2Join\" AS \"t2\" ON \"t1.b\" = \"t2.b\" NATURAL FULL JOIN \"table3Join\" AS \"t3\" ON \"t1.b\" = \"t3.b\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: myTable1)
             .leftJoin(myTable2)
             .on(myTable1.a == myTable2.c)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join LEFT JOIN table2Join ON table1Join.a = table2Join.c"
+        query = "SELECT * FROM \"table1Join\" LEFT JOIN \"table2Join\" ON \"table1Join.a\" = \"table2Join.c\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t1)
             .rawJoin("FULL JOIN", t2)
             .using(t1.b)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join AS t1 FULL JOIN table2Join AS t2 USING (b)"
+        query = "SELECT * FROM \"table1Join\" AS \"t1\" FULL JOIN \"table2Join\" AS \"t2\" USING (\"b\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t1)
             .rawJoin("FULL JOIN", t2)
             .using([t1.b])
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM table1Join AS t1 FULL JOIN table2Join AS t2 USING (b)"
+        query = "SELECT * FROM \"table1Join\" AS \"t1\" FULL JOIN \"table2Join\" AS \"t2\" USING (\"b\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(myTable1.a, from: myTable1)
             .union(Select(myTable2.c, from: myTable2))
             .unionAll(Select(myTable3.d, from: myTable3))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT table1Join.a FROM table1Join UNION SELECT table2Join.c FROM table2Join UNION ALL SELECT table3Join.d FROM table3Join"
+        query = "SELECT \"table1Join.a\" FROM \"table1Join\" UNION SELECT \"table2Join.c\" FROM \"table2Join\" UNION ALL SELECT \"table3Join.d\" FROM \"table3Join\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestParameters.swift
+++ b/Tests/SwiftKueryTests/TestParameters.swift
@@ -39,23 +39,23 @@ class TestParameters: XCTestCase {
         
         let i = Insert(into: t, rows: [[Parameter(), 10], ["apricot", Parameter()], [Parameter(), Parameter()]])
         var kuery = connection.descriptionOf(query: i)
-        var query = "INSERT INTO tableParameters VALUES (?1, 10), ('apricot', ?2), (?3, ?4)"
+        var query = "INSERT INTO \"tableParameters\" VALUES (?1, 10), ('apricot', ?2), (?3, ?4)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         var u = Update(t, set: [(t.a, Parameter()), (t.b, Parameter())], where: t.a == "banana")
         kuery = connection.descriptionOf(query: u)
-        query = "UPDATE tableParameters SET a = ?1, b = ?2 WHERE tableParameters.a = 'banana'"
+        query = "UPDATE \"tableParameters\" SET \"a\" = ?1, \"b\" = ?2 WHERE \"tableParameters.a\" = 'banana'"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         u = Update(t, set: [(t.a, Parameter("name")), (t.b, Parameter())], where: t.a == "banana")
         kuery = connection.descriptionOf(query: u)
-        query = "UPDATE tableParameters SET a = @name, b = ?1 WHERE tableParameters.a = 'banana'"
+        query = "UPDATE \"tableParameters\" SET \"a\" = @name, \"b\" = ?1 WHERE \"tableParameters.a\" = 'banana'"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         let d = Delete(from: t)
             .where(t.b == Parameter())
         kuery = connection.descriptionOf(query: d)
-        query = "DELETE FROM tableParameters WHERE tableParameters.b = ?1"
+        query = "DELETE FROM \"tableParameters\" WHERE \"tableParameters.b\" = ?1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         var s = Select(t.a, from: t)
@@ -64,13 +64,13 @@ class TestParameters: XCTestCase {
             .order(by: .DESC(t.a))
             .having(sum(t.b) < Parameter())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableParameters.a FROM tableParameters WHERE tableParameters.b NOT BETWEEN ?1 AND ?2 GROUP BY tableParameters.a HAVING SUM(tableParameters.b) < ?3 ORDER BY tableParameters.a DESC"
+        query = "SELECT \"tableParameters.a\" FROM \"tableParameters\" WHERE \"tableParameters.b\" NOT BETWEEN ?1 AND ?2 GROUP BY \"tableParameters.a\" HAVING SUM(\"tableParameters.b\") < ?3 ORDER BY \"tableParameters.a\" DESC"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(t.a, from: t)
             .where(t.a.like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableParameters.a FROM tableParameters WHERE tableParameters.a LIKE ?1"
+        query = "SELECT \"tableParameters.a\" FROM \"tableParameters\" WHERE \"tableParameters.a\" LIKE ?1"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestRaw.swift
+++ b/Tests/SwiftKueryTests/TestRaw.swift
@@ -38,12 +38,12 @@ class TestRaw: XCTestCase {
         
         var r = Raw(query: "DROP TABLE", table: t)
         var kuery = connection.descriptionOf(query: r)
-        var query = "DROP TABLE tableRaw"
+        var query = "DROP TABLE \"tableRaw\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         r = Raw(query: "DROP TABLE", tables: [t])
         kuery = connection.descriptionOf(query: r)
-        query = "DROP TABLE tableRaw"
+        query = "DROP TABLE \"tableRaw\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -77,12 +77,12 @@ class TestSchema: XCTestCase {
         
         var t1 = Table1()
         var createStmt = createTable(t1, connection: connection)
-        var expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0))"
+        var expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
         
         let t2 = Table2()
         createStmt = createTable(t2, connection: connection)
-        expectedCreateStmt = "CREATE TABLE table2 (a varchar, b varchar(20) UNIQUE, c smallint NOT NULL, d integer, e date, f timestamp, g mySQLType(15))"
+        expectedCreateStmt = "CREATE TABLE \"table2\" (\"a\" varchar, \"b\" varchar(20) UNIQUE, \"c\" smallint NOT NULL, \"d\" integer, \"e\" date, \"f\" timestamp, \"g\" mySQLType(15))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
         
         let t3 = Table3()
@@ -95,12 +95,12 @@ class TestSchema: XCTestCase {
         XCTAssertEqual(error, expectedError)
 
         createStmt = createTable(t2.primaryKey([t2.b, t2.c]), connection: connection)
-        expectedCreateStmt = "CREATE TABLE table2 (a varchar, b varchar(20) UNIQUE, c smallint NOT NULL, d integer, e date, f timestamp, g mySQLType(15), PRIMARY KEY (b, c))"
+        expectedCreateStmt = "CREATE TABLE \"table2\" (\"a\" varchar, \"b\" varchar(20) UNIQUE, \"c\" smallint NOT NULL, \"d\" integer, \"e\" date, \"f\" timestamp, \"g\" mySQLType(15), PRIMARY KEY (\"b\", \"c\"))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
 
         var t4 = Table4()
         createStmt = createTable(t4.primaryKey(t4.b).foreignKey(t4.a, references: t2.b), connection: connection)
-        expectedCreateStmt = "CREATE TABLE table4 (a char(20), b bigint, c real, d boolean, e time, PRIMARY KEY (b), FOREIGN KEY (a) REFERENCES table2(b))"
+        expectedCreateStmt = "CREATE TABLE \"table4\" (\"a\" char(20), \"b\" bigint, \"c\" real, \"d\" boolean, \"e\" time, PRIMARY KEY (\"b\"), FOREIGN KEY (\"a\") REFERENCES \"table2\"(\"b\"))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
         
         t4 = Table4()
@@ -141,7 +141,7 @@ class TestSchema: XCTestCase {
         t1 = Table1()
         let connectionWithAutoIncrement = createConnection(createAutoIncrement: createAutoIncrement)
         createStmt = createTable(t1, connection: connectionWithAutoIncrement)
-        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b auto_increment, c double DEFAULT 4.95 CHECK (c > 0))"
+        expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" auto_increment, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
     

--- a/Tests/SwiftKueryTests/TestSelect.swift
+++ b/Tests/SwiftKueryTests/TestSelect.swift
@@ -53,7 +53,7 @@ class TestSelect: XCTestCase {
         
         var s = Select(from: t)
         var kuery = connection.descriptionOf(query: s)
-        var query = "SELECT * FROM tableSelect"
+        var query = "SELECT * FROM \"tableSelect\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select.distinct(t.a, from: t)
@@ -61,7 +61,7 @@ class TestSelect: XCTestCase {
             .limit(to: 3)
             .offset(2)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT DISTINCT tableSelect.a FROM tableSelect WHERE (tableSelect.a NOT LIKE 'b%') IS NOT NULL LIMIT 3 OFFSET 2"
+        query = "SELECT DISTINCT \"tableSelect.a\" FROM \"tableSelect\" WHERE (\"tableSelect.a\" NOT LIKE 'b%') IS NOT NULL LIMIT 3 OFFSET 2"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select.distinct(t.a, from: t)
@@ -69,14 +69,14 @@ class TestSelect: XCTestCase {
             .limit(to: 3)
             .offset(2)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT DISTINCT tableSelect.a FROM tableSelect WHERE (tableSelect.a NOT LIKE 'b%') IS NULL LIMIT 3 OFFSET 2"
+        query = "SELECT DISTINCT \"tableSelect.a\" FROM \"tableSelect\" WHERE (\"tableSelect.a\" NOT LIKE 'b%') IS NULL LIMIT 3 OFFSET 2"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
  
         s = Select(t.b, t.a, from: t)
             .where(((t.a == "banana") || (ucase(t.a) == "APPLE")) && (t.b == 27 || t.b == -7 || t.b == 17))
             .order(by: [.ASC(t.b), .DESC(t.a)])
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.b, tableSelect.a FROM tableSelect WHERE ((tableSelect.a = 'banana') OR (UCASE(tableSelect.a) = 'APPLE')) AND (((tableSelect.b = 27) OR (tableSelect.b = -7)) OR (tableSelect.b = 17)) ORDER BY tableSelect.b ASC, tableSelect.a DESC"
+        query = "SELECT \"tableSelect.b\", \"tableSelect.a\" FROM \"tableSelect\" WHERE ((\"tableSelect.a\" = 'banana') OR (UCASE(\"tableSelect.a\") = 'APPLE')) AND (((\"tableSelect.b\" = 27) OR (\"tableSelect.b\" = -7)) OR (\"tableSelect.b\" = 17)) ORDER BY \"tableSelect.b\" ASC, \"tableSelect.a\" DESC"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(t.a, from: t)
@@ -85,35 +85,35 @@ class TestSelect: XCTestCase {
             .order(by: .DESC(t.a))
             .having(sum(t.b) > 3 || t.b.isNull())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect WHERE (tableSelect.b >= 0.76) IS NOT NULL GROUP BY tableSelect.a HAVING (SUM(tableSelect.b) > 3) OR (tableSelect.b IS NULL) ORDER BY tableSelect.a DESC"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" WHERE (\"tableSelect.b\" >= 0.76) IS NOT NULL GROUP BY \"tableSelect.a\" HAVING (SUM(\"tableSelect.b\") > 3) OR (\"tableSelect.b\" IS NULL) ORDER BY \"tableSelect.a\" DESC"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
  
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having((last(t.b) > 0).isNull())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect GROUP BY tableSelect.a HAVING (LAST(tableSelect.b) > 0) IS NULL"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" GROUP BY \"tableSelect.a\" HAVING (LAST(\"tableSelect.b\") > 0) IS NULL"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having((last(t.b) > 0).isNotNull())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect GROUP BY tableSelect.a HAVING (LAST(tableSelect.b) > 0) IS NOT NULL"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" GROUP BY \"tableSelect.a\" HAVING (LAST(\"tableSelect.b\") > 0) IS NOT NULL"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: [t.a])
             .having(last(t.b).isNull())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect GROUP BY tableSelect.a HAVING LAST(tableSelect.b) IS NULL"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" GROUP BY \"tableSelect.a\" HAVING LAST(\"tableSelect.b\") IS NULL"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(last(t.b).isNotNull())
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect GROUP BY tableSelect.a HAVING LAST(tableSelect.b) IS NOT NULL"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" GROUP BY \"tableSelect.a\" HAVING LAST(\"tableSelect.b\") IS NOT NULL"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(RawField("left(a, 2) as raw"), from: t)
@@ -122,32 +122,32 @@ class TestSelect: XCTestCase {
             .order(by: .DESC(t.a))
             .having("sum(b) > 3")
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT left(a, 2) as raw FROM tableSelect WHERE b >= 0 GROUP BY tableSelect.a HAVING sum(b) > 3 ORDER BY tableSelect.a DESC"
+        query = "SELECT left(a, 2) as raw FROM \"tableSelect\" WHERE b >= 0 GROUP BY \"tableSelect.a\" HAVING sum(b) > 3 ORDER BY \"tableSelect.a\" DESC"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(t.a, RawField("b").as("bb"), from: t)
             .limit(to: 2)
             .order(by: .DESC(t.a))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a, b AS bb FROM tableSelect ORDER BY tableSelect.a DESC LIMIT 2"
+        query = "SELECT \"tableSelect.a\", b AS \"bb\" FROM \"tableSelect\" ORDER BY \"tableSelect.a\" DESC LIMIT 2"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(ucase(t.a).as("case"), t.b, from: t)
             .where(t.a.between("apra", and: "aprt"))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT UCASE(tableSelect.a) AS case, tableSelect.b FROM tableSelect WHERE tableSelect.a BETWEEN 'apra' AND 'aprt'"
+        query = "SELECT UCASE(\"tableSelect.a\") AS \"case\", \"tableSelect.b\" FROM \"tableSelect\" WHERE \"tableSelect.a\" BETWEEN 'apra' AND 'aprt'"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t)
             .where(t.a.in("apple", "lalala"))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSelect WHERE tableSelect.a IN ('apple', 'lalala')"
+        query = "SELECT * FROM \"tableSelect\" WHERE \"tableSelect.a\" IN ('apple', 'lalala')"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t)
             .where("a IN ('apple', 'lalala')")
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSelect WHERE a IN ('apple', 'lalala')"
+        query = "SELECT * FROM \"tableSelect\" WHERE a IN ('apple', 'lalala')"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         let t2 = MyTable2()
@@ -156,19 +156,19 @@ class TestSelect: XCTestCase {
         s = Select(from: [t2, t3, t])
             .where((t2.b == t3.b) && (t2.b == t.b))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSelect2, tableSelect3, tableSelect WHERE (tableSelect2.b = tableSelect3.b) AND (tableSelect2.b = tableSelect.b)"
+        query = "SELECT * FROM \"tableSelect2\", \"tableSelect3\", \"tableSelect\" WHERE (\"tableSelect2.b\" = \"tableSelect3.b\") AND (\"tableSelect2.b\" = \"tableSelect.b\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(t.a, from: t)
             .where(len(ucase(t.a)) == 5 || ucase(lcase(t.a)) == "BANANA" || lcase(ucase(t.a)) == "banana")
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect WHERE ((LEN(UCASE(tableSelect.a)) = 5) OR (UCASE(LCASE(tableSelect.a)) = 'BANANA')) OR (LCASE(UCASE(tableSelect.a)) = 'banana')"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" WHERE ((LEN(UCASE(\"tableSelect.a\")) = 5) OR (UCASE(LCASE(\"tableSelect.a\")) = 'BANANA')) OR (LCASE(UCASE(\"tableSelect.a\")) = 'banana')"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(t.a, from: t)
             .where(len(t.a) >= round(len(t.b), to: 2) && mid(ucase(t.b), start: 3, length: 2) == t.a)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSelect.a FROM tableSelect WHERE (LEN(tableSelect.a) >= ROUND(LEN(tableSelect.b), 2)) AND (MID(UCASE(tableSelect.b), 3, 2) = tableSelect.a)"
+        query = "SELECT \"tableSelect.a\" FROM \"tableSelect\" WHERE (LEN(\"tableSelect.a\") >= ROUND(LEN(\"tableSelect.b\"), 2)) AND (MID(UCASE(\"tableSelect.b\"), 3, 2) = \"tableSelect.a\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
     
@@ -188,7 +188,7 @@ class TestSelect: XCTestCase {
         
         var s = with(withTable, Select(withTable.d, t.a, from: t).join(withTable).on(t.b == withTable.f))
         let kuery = connection.descriptionOf(query: s)
-        let query = "WITH aux_table AS (SELECT tableSelect2.c AS d, tableSelect2.b AS f FROM tableSelect2) SELECT aux_table.d, tableSelect.a FROM tableSelect JOIN aux_table ON tableSelect.b = aux_table.f"
+        let query = "WITH \"aux_table\" AS (SELECT \"tableSelect2.c\" AS \"d\", \"tableSelect2.b\" AS \"f\" FROM \"tableSelect2\") SELECT \"aux_table.d\", \"tableSelect.a\" FROM \"tableSelect\" JOIN \"aux_table\" ON \"tableSelect.b\" = \"aux_table.f\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         withTable = AuxTable()

--- a/Tests/SwiftKueryTests/TestSpecialOperators.swift
+++ b/Tests/SwiftKueryTests/TestSpecialOperators.swift
@@ -48,8 +48,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -57,16 +57,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(t.a.notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -74,16 +74,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where(t.a.notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -91,16 +91,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(t.a.notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -108,16 +108,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where(ucase(t.a).notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -125,16 +125,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(first(t.a).notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -142,16 +142,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(first(t.a).like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where(ucase(t.a).notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -159,16 +159,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(first(t.a).notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -176,16 +176,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(first(t.a).like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING FIRST(table.a) LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING FIRST(table.a) LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING FIRST(\"table.a\") LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING FIRST(\"table.a\") LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where("swift-kuery".notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'swift-kuery' NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'swift-kuery' NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'swift-kuery' NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'swift-kuery' NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -193,16 +193,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("swift-kuery".like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'swift-kuery' LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'swift-kuery' LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'swift-kuery' LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'swift-kuery' LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having("swift-kuery".notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'swift-kuery' NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'swift-kuery' NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'swift-kuery' NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'swift-kuery' NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -210,16 +210,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("swift-kuery".like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'swift-kuery' LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'swift-kuery' LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'swift-kuery' LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'swift-kuery' LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where("swift-kuery".notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'swift-kuery' NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'swift-kuery' NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'swift-kuery' NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'swift-kuery' NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -227,16 +227,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("swift-kuery".like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'swift-kuery' LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'swift-kuery' LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'swift-kuery' LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'swift-kuery' LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having("swift-kuery".notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'swift-kuery' NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'swift-kuery' NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'swift-kuery' NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'swift-kuery' NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -244,16 +244,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("swift-kuery".like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'swift-kuery' LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'swift-kuery' LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'swift-kuery' LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'swift-kuery' LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where(Parameter().notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -261,16 +261,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter().like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE ?1 LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(Parameter("first").notLike("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first NOT LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first NOT LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first NOT LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first NOT LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -278,16 +278,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter("first").like("%kuery%"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first LIKE '%kuery%' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first LIKE '%kuery%'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first LIKE '%kuery%' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first LIKE '%kuery%'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .where(Parameter("first").notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first NOT LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first NOT LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first NOT LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first NOT LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -295,16 +295,16 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter("first").like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first LIKE ?1 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first LIKE ?1"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first LIKE ?1 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first LIKE ?1"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(Parameter().notLike(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 NOT LIKE ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 NOT LIKE ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 NOT LIKE ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 NOT LIKE ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -312,8 +312,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter().like(Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 LIKE ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 LIKE ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 LIKE ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 LIKE ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -321,8 +321,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -330,8 +330,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -339,8 +339,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -348,8 +348,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -357,8 +357,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -366,8 +366,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -375,8 +375,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -384,8 +384,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -393,8 +393,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -402,8 +402,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -411,8 +411,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -420,8 +420,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -429,8 +429,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -438,8 +438,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -447,8 +447,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -456,8 +456,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -465,8 +465,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -474,8 +474,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -483,8 +483,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -492,8 +492,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -501,8 +501,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -510,8 +510,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -519,8 +519,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -528,8 +528,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -537,8 +537,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -546,8 +546,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -555,8 +555,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -564,8 +564,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -573,8 +573,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -582,8 +582,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -591,8 +591,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -600,8 +600,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -609,8 +609,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -618,8 +618,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -627,8 +627,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -636,8 +636,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -645,8 +645,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -654,8 +654,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -663,8 +663,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -672,8 +672,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -681,8 +681,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -690,8 +690,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -699,8 +699,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -708,8 +708,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(t.a.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -717,8 +717,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -726,8 +726,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -735,8 +735,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -744,8 +744,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(t.a.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -753,8 +753,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -762,8 +762,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -771,8 +771,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -780,8 +780,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -789,8 +789,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -798,8 +798,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -807,8 +807,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -816,8 +816,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -825,8 +825,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -834,8 +834,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -843,8 +843,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -852,8 +852,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -861,8 +861,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -870,8 +870,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -879,8 +879,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -888,8 +888,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -897,8 +897,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -906,8 +906,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -915,8 +915,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -924,8 +924,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -933,8 +933,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -942,8 +942,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -951,8 +951,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -960,8 +960,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -969,8 +969,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -978,8 +978,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -987,8 +987,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -996,8 +996,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1005,8 +1005,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1014,8 +1014,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween(2.71828, and: 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1023,8 +1023,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1032,8 +1032,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn(2.71828, 3.14159))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1041,8 +1041,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1050,8 +1050,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1059,8 +1059,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1068,8 +1068,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1077,8 +1077,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1086,8 +1086,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1095,8 +1095,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1104,8 +1104,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1113,8 +1113,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1122,8 +1122,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1131,8 +1131,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1140,8 +1140,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a).notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1149,8 +1149,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1158,8 +1158,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1167,8 +1167,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1176,8 +1176,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(last(t.a).notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING LAST(table.a) NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING LAST(table.a) NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING LAST(\"table.a\") NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING LAST(\"table.a\") NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1185,8 +1185,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1194,8 +1194,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1203,8 +1203,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1212,8 +1212,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1221,8 +1221,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.between(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1230,8 +1230,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.notBetween(true, and: false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true NOT BETWEEN true AND false GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true NOT BETWEEN true AND false"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true NOT BETWEEN true AND false GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true NOT BETWEEN true AND false"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1239,8 +1239,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.in(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1248,8 +1248,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.notIn(true, false))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true NOT IN (true, false) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true NOT IN (true, false)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true NOT IN (true, false) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true NOT IN (true, false)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1257,8 +1257,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1266,8 +1266,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1275,8 +1275,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1284,8 +1284,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(true.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1293,8 +1293,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1302,8 +1302,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1311,8 +1311,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1320,8 +1320,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(true.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1329,8 +1329,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1338,8 +1338,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1347,8 +1347,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1356,8 +1356,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1365,8 +1365,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".between("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1374,8 +1374,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".notBetween("apple", and: "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' NOT BETWEEN 'apple' AND 'peach' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' NOT BETWEEN 'apple' AND 'peach'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' NOT BETWEEN 'apple' AND 'peach' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' NOT BETWEEN 'apple' AND 'peach'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1383,8 +1383,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".in("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1392,8 +1392,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".notIn("apple", "peach"))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' NOT IN ('apple', 'peach') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' NOT IN ('apple', 'peach')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' NOT IN ('apple', 'peach') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' NOT IN ('apple', 'peach')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1401,8 +1401,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".between(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1410,8 +1410,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".notBetween(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' NOT BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' NOT BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' NOT BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' NOT BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1419,8 +1419,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".in(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1428,8 +1428,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where("banana".notIn(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'banana' NOT IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'banana' NOT IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'banana' NOT IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'banana' NOT IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1437,8 +1437,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".between(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1446,8 +1446,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".notBetween(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' NOT BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' NOT BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' NOT BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' NOT BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1455,8 +1455,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".in(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1464,8 +1464,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having("banana".notIn(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'banana' NOT IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'banana' NOT IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'banana' NOT IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'banana' NOT IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1473,8 +1473,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1482,8 +1482,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1491,8 +1491,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1500,8 +1500,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1509,8 +1509,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.between(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1518,8 +1518,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.notBetween(3, and: 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 NOT BETWEEN 3 AND 6 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 NOT BETWEEN 3 AND 6"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 NOT BETWEEN 3 AND 6 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 NOT BETWEEN 3 AND 6"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1527,8 +1527,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.in(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1536,8 +1536,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.notIn(3, 6))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 NOT IN (3, 6) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 NOT IN (3, 6)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 NOT IN (3, 6) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 NOT IN (3, 6)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1545,8 +1545,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1554,8 +1554,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1563,8 +1563,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1572,8 +1572,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(4.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 4 NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 4 NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 4 NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 4 NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1581,8 +1581,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.between(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1590,8 +1590,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.notBetween(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 NOT BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 NOT BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 NOT BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 NOT BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1599,8 +1599,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.in(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1608,8 +1608,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(4.notIn(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 4 NOT IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 4 NOT IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 4 NOT IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 4 NOT IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1617,8 +1617,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).between(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1626,8 +1626,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).notBetween(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1635,8 +1635,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).in(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1644,8 +1644,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).notIn(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1653,8 +1653,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).between(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1662,8 +1662,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).notBetween(Float(2.71828), and: Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 NOT BETWEEN 2.71828 AND 3.14159 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 NOT BETWEEN 2.71828 AND 3.14159"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 NOT BETWEEN 2.71828 AND 3.14159 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 NOT BETWEEN 2.71828 AND 3.14159"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1671,8 +1671,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).in(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1680,8 +1680,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).notIn(Float(2.71828), Float(3.14159)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 NOT IN (2.71828, 3.14159) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 NOT IN (2.71828, 3.14159)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 NOT IN (2.71828, 3.14159) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 NOT IN (2.71828, 3.14159)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1689,8 +1689,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.between(3.14159, and: 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 BETWEEN 3.14159 AND 2.71828 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 BETWEEN 3.14159 AND 2.71828"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 BETWEEN 3.14159 AND 2.71828 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 BETWEEN 3.14159 AND 2.71828"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1698,8 +1698,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.notBetween(3.14159, and: 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 NOT BETWEEN 3.14159 AND 2.71828 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 NOT BETWEEN 3.14159 AND 2.71828"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 NOT BETWEEN 3.14159 AND 2.71828 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 NOT BETWEEN 3.14159 AND 2.71828"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1707,8 +1707,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.in(3.14159, 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 IN (3.14159, 2.71828) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 IN (3.14159, 2.71828)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 IN (3.14159, 2.71828) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 IN (3.14159, 2.71828)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1716,8 +1716,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.notIn(3.14159, 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 NOT IN (3.14159, 2.71828) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 NOT IN (3.14159, 2.71828)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 NOT IN (3.14159, 2.71828) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 NOT IN (3.14159, 2.71828)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1725,8 +1725,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.between(3.14159, and: 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 BETWEEN 3.14159 AND 2.71828 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 BETWEEN 3.14159 AND 2.71828"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 BETWEEN 3.14159 AND 2.71828 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 BETWEEN 3.14159 AND 2.71828"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1734,8 +1734,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.notBetween(3.14159, and: 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 NOT BETWEEN 3.14159 AND 2.71828 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 NOT BETWEEN 3.14159 AND 2.71828"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 NOT BETWEEN 3.14159 AND 2.71828 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 NOT BETWEEN 3.14159 AND 2.71828"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1743,8 +1743,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.in(3.14159, 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 IN (3.14159, 2.71828) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 IN (3.14159, 2.71828)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 IN (3.14159, 2.71828) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 IN (3.14159, 2.71828)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1752,8 +1752,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.notIn(3.14159, 2.71828))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 NOT IN (3.14159, 2.71828) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 NOT IN (3.14159, 2.71828)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 NOT IN (3.14159, 2.71828) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 NOT IN (3.14159, 2.71828)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1761,8 +1761,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1770,8 +1770,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1779,8 +1779,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1788,8 +1788,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Float(2.71828).notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 2.71828 NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 2.71828 NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 2.71828 NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 2.71828 NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1797,8 +1797,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).between(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1806,8 +1806,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).notBetween(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 NOT BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 NOT BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 NOT BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 NOT BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1815,8 +1815,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).in(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1824,8 +1824,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Float(2.71828).notIn(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 2.71828 NOT IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 2.71828 NOT IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 2.71828 NOT IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 2.71828 NOT IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1833,8 +1833,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.between(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1842,8 +1842,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.notBetween(Parameter("first"), and: Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 NOT BETWEEN @first AND @second GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 NOT BETWEEN @first AND @second"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 NOT BETWEEN @first AND @second GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 NOT BETWEEN @first AND @second"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1851,8 +1851,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.in(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1860,8 +1860,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(3.001.notIn(Parameter("first"), Parameter("second")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.001 NOT IN (@first, @second) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.001 NOT IN (@first, @second)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.001 NOT IN (@first, @second) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.001 NOT IN (@first, @second)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1869,8 +1869,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.between(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1878,8 +1878,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.notBetween(Parameter(), and: Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 NOT BETWEEN ?1 AND ?2 GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 NOT BETWEEN ?1 AND ?2"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 NOT BETWEEN ?1 AND ?2 GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 NOT BETWEEN ?1 AND ?2"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1887,8 +1887,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1896,8 +1896,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(3.008.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.008 NOT IN (?1, ?2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.008 NOT IN (?1, ?2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.008 NOT IN (?1, ?2) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.008 NOT IN (?1, ?2)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1905,8 +1905,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter("first").between(Parameter("second"), and: Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first BETWEEN @second AND @third GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first BETWEEN @second AND @third"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first BETWEEN @second AND @third GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first BETWEEN @second AND @third"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1914,8 +1914,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter("first").notBetween(Parameter("second"), and: Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first NOT BETWEEN @second AND @third GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first NOT BETWEEN @second AND @third"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first NOT BETWEEN @second AND @third GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first NOT BETWEEN @second AND @third"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1923,8 +1923,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter("first").in(Parameter("second"), Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first IN (@second, @third) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first IN (@second, @third)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first IN (@second, @third) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first IN (@second, @third)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1932,8 +1932,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Parameter("first").notIn(Parameter("second"), Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @first NOT IN (@second, @third) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @first NOT IN (@second, @third)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @first NOT IN (@second, @third) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @first NOT IN (@second, @third)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1941,8 +1941,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter("first").between(Parameter("second"), and: Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first BETWEEN @second AND @third GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first BETWEEN @second AND @third"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first BETWEEN @second AND @third GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first BETWEEN @second AND @third"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1950,8 +1950,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter("first").notBetween(Parameter("second"), and: Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first NOT BETWEEN @second AND @third GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first NOT BETWEEN @second AND @third"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first NOT BETWEEN @second AND @third GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first NOT BETWEEN @second AND @third"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1959,8 +1959,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter("first").in(Parameter("second"), Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first IN (@second, @third) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first IN (@second, @third)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first IN (@second, @third) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first IN (@second, @third)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1968,8 +1968,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Parameter("first").notIn(Parameter("second"), Parameter("third")))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING @first NOT IN (@second, @third) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING @first NOT IN (@second, @third)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING @first NOT IN (@second, @third) GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING @first NOT IN (@second, @third)"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1977,8 +1977,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000).between(Date(timeIntervalSince1970: 50000), and: Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1986,8 +1986,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000).notBetween(Date(timeIntervalSince1970: 50000), and: Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1995,8 +1995,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000).in(Date(timeIntervalSince1970: 50000), Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2004,8 +2004,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .where(Date(timeIntervalSince1970: 50000).notIn(Date(timeIntervalSince1970: 50000), Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2013,8 +2013,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000).between(Date(timeIntervalSince1970: 50000), and: Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2022,8 +2022,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000).notBetween(Date(timeIntervalSince1970: 50000), and: Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000' GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' NOT BETWEEN '1970-01-01 13:53:20 +0000' AND '1970-01-01 00:00:00 +0000'"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2031,8 +2031,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000).in(Date(timeIntervalSince1970: 50000), Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -2040,8 +2040,8 @@ class TestSpecialOperators: XCTestCase {
             .group(by: t.a)
             .having(Date(timeIntervalSince1970: 50000).notIn(Date(timeIntervalSince1970: 50000), Date(timeIntervalSince1970: 0)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000') GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 13:53:20 +0000' NOT IN ('1970-01-01 13:53:20 +0000', '1970-01-01 00:00:00 +0000')"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
   }

--- a/Tests/SwiftKueryTests/TestSubqueries.swift
+++ b/Tests/SwiftKueryTests/TestSubqueries.swift
@@ -55,8 +55,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -64,8 +64,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" == all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' = ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' = ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' = ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' = ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -73,8 +73,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -82,8 +82,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -91,8 +91,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -100,8 +100,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -109,8 +109,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -118,8 +118,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true == all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true = ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true = ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true = ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true = ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -127,8 +127,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -136,8 +136,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" == all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' = ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' = ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' = ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' = ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -145,8 +145,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -154,8 +154,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -163,8 +163,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -172,8 +172,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -181,8 +181,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() == any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 = ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 = ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 = ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 = ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -190,8 +190,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true == all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true = ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true = ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true = ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true = ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -199,8 +199,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -208,8 +208,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" >= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' >= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' >= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' >= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' >= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -217,8 +217,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -226,8 +226,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -235,8 +235,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -244,8 +244,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -253,8 +253,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -262,8 +262,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true >= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true >= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true >= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true >= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true >= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -271,8 +271,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -280,8 +280,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" >= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' >= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' >= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' >= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' >= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -289,8 +289,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -298,8 +298,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -307,8 +307,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -316,8 +316,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -325,8 +325,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() >= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 >= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 >= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 >= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 >= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -334,8 +334,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true >= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true >= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true >= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true >= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true >= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -343,8 +343,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -352,8 +352,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" > all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' > ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' > ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' > ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' > ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -361,8 +361,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -370,8 +370,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -379,8 +379,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -388,8 +388,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -397,8 +397,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -406,8 +406,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true > all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true > ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true > ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true > ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true > ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -415,8 +415,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -424,8 +424,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" > all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' > ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' > ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' > ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' > ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -433,8 +433,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -442,8 +442,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -451,8 +451,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -460,8 +460,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -469,8 +469,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() > any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 > ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 > ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 > ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 > ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -478,8 +478,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true > all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true > ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true > ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true > ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true > ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -487,8 +487,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -496,8 +496,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" <= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' <= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' <= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' <= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' <= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -505,8 +505,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -514,8 +514,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -523,8 +523,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -532,8 +532,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -541,8 +541,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -550,8 +550,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true <= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true <= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true <= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true <= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true <= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -559,8 +559,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -568,8 +568,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" <= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' <= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' <= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' <= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' <= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -577,8 +577,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -586,8 +586,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -595,8 +595,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -604,8 +604,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -613,8 +613,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() <= any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <= ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <= ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <= ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <= ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -622,8 +622,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true <= all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true <= ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true <= ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true <= ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true <= ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -631,8 +631,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -640,8 +640,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" < all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' < ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' < ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' < ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' < ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -649,8 +649,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -658,8 +658,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -667,8 +667,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -676,8 +676,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -685,8 +685,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -694,8 +694,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true < all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true < ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true < ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true < ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true < ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -703,8 +703,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -712,8 +712,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" < all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' < ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' < ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' < ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' < ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -721,8 +721,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -730,8 +730,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -739,8 +739,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -748,8 +748,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -757,8 +757,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() < any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 < ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 < ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 < ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 < ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -766,8 +766,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true < all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true < ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true < ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true < ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true < ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -775,8 +775,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(ucase(t.a) != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE UCASE(table.a) <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE UCASE(table.a) <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE UCASE(\"table.a\") <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE UCASE(\"table.a\") <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -784,8 +784,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where("peach" != all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 'peach' <> ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'peach' <> ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'peach' <> ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'peach' <> ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -793,8 +793,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(t.a != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE table.a <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -802,8 +802,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(3 != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -811,8 +811,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Float(3.5) != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE 3.5 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 3.5 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 3.5 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 3.5 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -820,8 +820,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(-8.1 != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE -8.1 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -8.1 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -8.1 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -8.1 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -829,8 +829,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(Parameter("fruit") != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE @fruit <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE @fruit <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE @fruit <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE @fruit <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -838,8 +838,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .where(true != all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table WHERE true <> ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true <> ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true <> ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true <> ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -847,8 +847,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(sum(t.a) != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING SUM(table.a) <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING SUM(table.a) <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING SUM(\"table.a\") <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING SUM(\"table.a\") <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -856,8 +856,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having("peach" != all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 'peach' <> ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'peach' <> ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'peach' <> ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'peach' <> ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -865,8 +865,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(t.a != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING table.a <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -874,8 +874,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(3 != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -883,8 +883,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Float(3.5) != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING 3.5 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 3.5 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 3.5 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 3.5 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -892,8 +892,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(-8.1 != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING -8.1 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -8.1 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -8.1 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -8.1 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -901,8 +901,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(Parameter() != any(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING ?1 <> ANY (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 <> ANY (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 <> ANY (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 <> ANY (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -910,8 +910,8 @@ class TestSubqueries: XCTestCase {
             .group(by: t.a)
             .having(true != all(Select(t2.c, from: t2)))
         kuery = connection.descriptionOf(query: s)
-        queryWhere = "SELECT table.a FROM table HAVING true <> ALL (SELECT table2.c FROM table2) GROUP BY table.a"
-        queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING true <> ALL (SELECT table2.c FROM table2)"
+        queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING true <> ALL (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+        queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING true <> ALL (SELECT \"table2.c\" FROM \"table2\")"
         XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -919,8 +919,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(lcase(t.a).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -928,8 +928,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(lcase(t.a).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE LCASE(table.a) NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE LCASE(table.a) NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE LCASE(\"table.a\") NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE LCASE(\"table.a\") NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -937,8 +937,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where("plum".in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 'plum' IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'plum' IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'plum' IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'plum' IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -946,8 +946,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where("plum".notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 'plum' NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 'plum' NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 'plum' NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 'plum' NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -955,8 +955,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(t.a.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE table.a IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -964,8 +964,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(t.a.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE table.a NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE table.a NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE \"table.a\" NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE \"table.a\" NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -973,8 +973,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(7.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 7 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -982,8 +982,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(7.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 7 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -991,8 +991,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Float(7.8).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 7.8 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.8 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.8 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.8 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1000,8 +1000,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Float(7.8).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE 7.8 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE 7.8 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE 7.8 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE 7.8 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1009,8 +1009,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where((-0.9).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE -0.9 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -0.9 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -0.9 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -0.9 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1018,8 +1018,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where((-0.9).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE -0.9 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE -0.9 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE -0.9 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE -0.9 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1027,8 +1027,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Parameter().in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE ?1 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1036,8 +1036,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Parameter().notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE ?1 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE ?1 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE ?1 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE ?1 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1045,8 +1045,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(true.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE true IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1054,8 +1054,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(true.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE true NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE true NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE true NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE true NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1063,8 +1063,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Date(timeIntervalSince1970: 0).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1072,8 +1072,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .where(Date(timeIntervalSince1970: 0).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table WHERE '1970-01-01 00:00:00 +0000' NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a WHERE '1970-01-01 00:00:00 +0000' NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" WHERE '1970-01-01 00:00:00 +0000' NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" WHERE '1970-01-01 00:00:00 +0000' NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1081,8 +1081,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(min(t.a).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1090,8 +1090,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(min(t.a).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING MIN(table.a) NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING MIN(table.a) NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING MIN(\"table.a\") NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING MIN(\"table.a\") NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1099,8 +1099,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having("plum".in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 'plum' IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'plum' IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'plum' IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'plum' IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1108,8 +1108,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having("plum".notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 'plum' NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 'plum' NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 'plum' NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 'plum' NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1117,8 +1117,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(t.a.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING table.a IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1126,8 +1126,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(t.a.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING table.a NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING table.a NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING \"table.a\" NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING \"table.a\" NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1135,8 +1135,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(7.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 7 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1144,8 +1144,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(7.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 7 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1153,8 +1153,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Float(7.8).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 7.8 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.8 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.8 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.8 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1162,8 +1162,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Float(7.8).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING 7.8 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING 7.8 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING 7.8 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING 7.8 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1171,8 +1171,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having((-0.9).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING -0.9 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -0.9 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -0.9 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -0.9 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1180,8 +1180,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having((-0.9).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING -0.9 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING -0.9 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING -0.9 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING -0.9 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1189,8 +1189,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Parameter().in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING ?1 IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1198,8 +1198,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Parameter().notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING ?1 NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING ?1 NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING ?1 NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING ?1 NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1207,8 +1207,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(false.in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING false IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING false IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING false IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING false IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1216,8 +1216,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(false.notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING false NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING false NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING false NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING false NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1225,8 +1225,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Date(timeIntervalSince1970: 0).in(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                 "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
 
@@ -1234,8 +1234,8 @@ class TestSubqueries: XCTestCase {
         .group(by: t.a)
         .having(Date(timeIntervalSince1970: 0).notIn(Select(t2.c, from: t2)))
     kuery = connection.descriptionOf(query: s)
-    queryWhere = "SELECT table.a FROM table HAVING '1970-01-01 00:00:00 +0000' NOT IN (SELECT table2.c FROM table2) GROUP BY table.a"
-    queryHaving = "SELECT table.a FROM table GROUP BY table.a HAVING '1970-01-01 00:00:00 +0000' NOT IN (SELECT table2.c FROM table2)"
+    queryWhere = "SELECT \"table.a\" FROM \"table\" HAVING '1970-01-01 00:00:00 +0000' NOT IN (SELECT \"table2.c\" FROM \"table2\") GROUP BY \"table.a\""
+    queryHaving = "SELECT \"table.a\" FROM \"table\" GROUP BY \"table.a\" HAVING '1970-01-01 00:00:00 +0000' NOT IN (SELECT \"table2.c\" FROM \"table2\")"
     XCTAssert(kuery == queryWhere || kuery == queryHaving,
                     "\nError in query construction: \n\(kuery) \ninstead of \n\(queryWhere) \nor instead of \n\(queryHaving)")
   }

--- a/Tests/SwiftKueryTests/TestSubquery.swift
+++ b/Tests/SwiftKueryTests/TestSubquery.swift
@@ -39,72 +39,72 @@ class TestSubquery: XCTestCase {
         var s = Select(from: t)
             .where(t.b == any(Select(t.b, from: t).where(t.b == 2)))
         var kuery = connection.descriptionOf(query: s)
-        var query = "SELECT * FROM tableSubquery WHERE tableSubquery.b = ANY (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 2)"
+        var query = "SELECT * FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = ANY (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 2)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(t.a, from: t)
             .group(by: t.a)
             .having(sum(t.b) == any(Select(t.b, from: t).where(t.b == 2)))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT tableSubquery.a FROM tableSubquery GROUP BY tableSubquery.a HAVING SUM(tableSubquery.b) = ANY (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 2)"
+        query = "SELECT \"tableSubquery.a\" FROM \"tableSubquery\" GROUP BY \"tableSubquery.a\" HAVING SUM(\"tableSubquery.b\") = ANY (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 2)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t)
             .where(exists(Select(t.b, from: t).where(t.b == 2)))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery WHERE EXISTS (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 2)"
+        query = "SELECT * FROM \"tableSubquery\" WHERE EXISTS (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 2)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t)
             .where(8.in(1,6,8))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery WHERE 8 IN (1, 6, 8)"
+        query = "SELECT * FROM \"tableSubquery\" WHERE 8 IN (1, 6, 8)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .group(by: t.a)
             .having("apple".in("plum"))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery GROUP BY tableSubquery.a HAVING 'apple' IN ('plum')"
+        query = "SELECT * FROM \"tableSubquery\" GROUP BY \"tableSubquery.a\" HAVING 'apple' IN ('plum')"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         s = Select(from: t)
             .where(8.in(Select(t.b, from: t).where(t.b == 8)))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery WHERE 8 IN (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 8)"
+        query = "SELECT * FROM \"tableSubquery\" WHERE 8 IN (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 8)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .group(by: t.a)
             .having(exists(Select(t.b, from: t).where(t.b == 8)))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery GROUP BY tableSubquery.a HAVING EXISTS (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 8)"
+        query = "SELECT * FROM \"tableSubquery\" GROUP BY \"tableSubquery.a\" HAVING EXISTS (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 8)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .group(by: t.a)
             .having(notExists(Select(t.b, from: t).where(t.b == 8)) && sum(t.b) > 0)
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery GROUP BY tableSubquery.a HAVING (NOT EXISTS (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 8)) AND (SUM(tableSubquery.b) > 0)"
+        query = "SELECT * FROM \"tableSubquery\" GROUP BY \"tableSubquery.a\" HAVING (NOT EXISTS (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 8)) AND (SUM(\"tableSubquery.b\") > 0)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .where(notExists(Select(t.b, from: t).where(t.b == 8)))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery WHERE NOT EXISTS (SELECT tableSubquery.b FROM tableSubquery WHERE tableSubquery.b = 8)"
+        query = "SELECT * FROM \"tableSubquery\" WHERE NOT EXISTS (SELECT \"tableSubquery.b\" FROM \"tableSubquery\" WHERE \"tableSubquery.b\" = 8)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .group(by: t.a)
             .having(Parameter().in(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery GROUP BY tableSubquery.a HAVING ?1 IN (?2, ?3)"
+        query = "SELECT * FROM \"tableSubquery\" GROUP BY \"tableSubquery.a\" HAVING ?1 IN (?2, ?3)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         s = Select(from: t)
             .where(false.notIn(Parameter(), Parameter()))
         kuery = connection.descriptionOf(query: s)
-        query = "SELECT * FROM tableSubquery WHERE false NOT IN (?1, ?2)"
+        query = "SELECT * FROM \"tableSubquery\" WHERE false NOT IN (?1, ?2)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -47,37 +47,37 @@ class TestUpdate: XCTestCase {
         var u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .where(t.a == "banana")
         var kuery = connection.descriptionOf(query: u)
-        var query = "UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = 'banana'"
+        var query = "UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 WHERE \"tableUpdate.a\" = 'banana'"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
  
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .where(t.a == "banana")
             .suffix("RETURNING *")
         kuery = connection.descriptionOf(query: u)
-        query = "UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a = 'banana' RETURNING *"
+        query = "UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 WHERE \"tableUpdate.a\" = 'banana' RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
  
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .suffix("RETURNING b,a")
         kuery = connection.descriptionOf(query: u)
-        query = "UPDATE tableUpdate SET a = 'peach', b = 2 RETURNING b,a"
+        query = "UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 RETURNING b,a"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         u = Update(t, set: [(t.a, "peach"), (t.b, 2)])
             .suffix("RETURNING tableUpdate.b")
         kuery = connection.descriptionOf(query: u)
-        query = "UPDATE tableUpdate SET a = 'peach', b = 2 RETURNING tableUpdate.b"
+        query = "UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 RETURNING tableUpdate.b"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         var d = Delete(from: t)
             .where(t.b == "2" && t.a.isNull())
         kuery = connection.descriptionOf(query: d)
-        query = "DELETE FROM tableUpdate WHERE (tableUpdate.b = '2') AND (tableUpdate.a IS NULL)"
+        query = "DELETE FROM \"tableUpdate\" WHERE (\"tableUpdate.b\" = '2') AND (\"tableUpdate.a\" IS NULL)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         d = Delete(from: t)
         kuery = connection.descriptionOf(query: d)
-        query = "DELETE FROM tableUpdate"
+        query = "DELETE FROM \"tableUpdate\""
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
     
@@ -98,10 +98,10 @@ class TestUpdate: XCTestCase {
                      Update(t, set: [(t.a, "peach"), (t.b, 2)])
                         .where(t.a.in(Select(withTable.c, from: withTable))))
         var kuery = connection.descriptionOf(query: u)
-        var query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 WHERE tableUpdate.a IN (SELECT aux_table.c FROM aux_table)"
+        var query = "WITH \"aux_table\" AS (SELECT \"tableUpdate2.a\" AS \"c\" FROM \"tableUpdate2\") UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 WHERE \"tableUpdate.a\" IN (SELECT \"aux_table.c\" FROM \"aux_table\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         kuery = connection2.descriptionOf(query: u)
-        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) UPDATE tableUpdate SET a = 'peach', b = 2 FROM aux_table WHERE tableUpdate.a IN (SELECT aux_table.c FROM aux_table)"
+        query = "WITH \"aux_table\" AS (SELECT \"tableUpdate2.a\" AS \"c\" FROM \"tableUpdate2\") UPDATE \"tableUpdate\" SET \"a\" = 'peach', \"b\" = 2 FROM \"aux_table\" WHERE \"tableUpdate.a\" IN (SELECT \"aux_table.c\" FROM \"aux_table\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
         
@@ -109,10 +109,10 @@ class TestUpdate: XCTestCase {
                      Delete(from: t)
                         .where(t.b.in(Select(withTable.c, from: withTable))))
         kuery = connection.descriptionOf(query: d)
-        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate WHERE tableUpdate.b IN (SELECT aux_table.c FROM aux_table)"
+        query = "WITH \"aux_table\" AS (SELECT \"tableUpdate2.a\" AS \"c\" FROM \"tableUpdate2\") DELETE FROM \"tableUpdate\" WHERE \"tableUpdate.b\" IN (SELECT \"aux_table.c\" FROM \"aux_table\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         kuery = connection2.descriptionOf(query: d)
-        query = "WITH aux_table AS (SELECT tableUpdate2.a AS c FROM tableUpdate2) DELETE FROM tableUpdate USING aux_table WHERE tableUpdate.b IN (SELECT aux_table.c FROM aux_table)"
+        query = "WITH \"aux_table\" AS (SELECT \"tableUpdate2.a\" AS \"c\" FROM \"tableUpdate2\") DELETE FROM \"tableUpdate\" USING \"aux_table\" WHERE \"tableUpdate.b\" IN (SELECT \"aux_table.c\" FROM \"aux_table\")"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
         withTable = AuxTable()


### PR DESCRIPTION
Add case protection for names.

- Updated SwiftKuery tests to check all identifiers are wrapped in "'s. (apart from raw strings)
- Updated build functions to wrap identifiers when building SQL statements.

Mixed case column names now work consistently across postgreSQL, mySQL and SQLite.
