### PR TITLE
Fixed not using provided date formatter

### DIFF
--- a/Sources/SwiftKuery/Predicate.swift
+++ b/Sources/SwiftKuery/Predicate.swift
@@ -81,7 +81,7 @@ public indirect enum Predicate<ClauseType: Buildable, ColumnExpressionType: Fiel
         case .bool(let value):
             return try Utils.packType(value, queryBuilder: queryBuilder)
         case .date(let value):
-            return Utils.packType(value)
+            return try Utils.packType(value, queryBuilder: queryBuilder)
         case .column(let column):
             return try column.build(queryBuilder: queryBuilder)
         case .columnExpression(let columnExpression):


### PR DESCRIPTION
I have already signed the CLA.

This fixes a bug where dates were not correctly formatted in certain queries, as the query builder was not used.