### PR TITLE
Improve foreign key support

### DIFF
--- a/Sources/SwiftKuery/ForeignKey.swift
+++ b/Sources/SwiftKuery/ForeignKey.swift
@@ -1,0 +1,92 @@
+/**
+ Copyright IBM Corporation 2016, 2017, 2018
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+struct ForeignKey: Hashable {
+    var keyColumns: [Column]
+    var refColumns: [Column]
+    var keyNames: [String]
+    var refNames: [String]
+
+    public init?(keys: [Column], refs: [Column],_ tableName: String, _ errorString: inout String) {
+        if !ForeignKey.validKey(keys, refs, tableName, &errorString) {
+            return nil
+        }
+        keyColumns = keys
+        refColumns = refs
+        keyNames = keyColumns.map { "\($0._table._name).\($0.name)"}
+        refNames = refColumns.map { "\($0._table._name).\($0.name)"}
+    }
+
+    static func validKey(_ keys: [Column], _ refs: [Column],_ tableName: String, _ errorString: inout String) -> Bool {
+        if keys.count == 0 || refs.count == 0 || keys.count != refs.count {
+            errorString = "Invalid definition of foreign key. "
+            return false
+        }
+        else if !columnsBelongToSameTable(columns: keys, tableName: tableName) {
+            errorString = "Foreign key contains columns from another table. "
+            return false
+        }
+        else if !columnsBelongToSameTable(columns: refs, tableName: refs[0]._table._name) {
+            errorString = "Foreign key references columns from more than one table. "
+            return false
+        }
+        return true
+    }
+
+    static func columnsBelongToSameTable(columns: [Column], tableName: String) -> Bool {
+        for column in columns {
+            if column.table._name != tableName {
+                return false
+            }
+        }
+        return true
+    }
+
+    public var hashValue: Int {
+        var hashvalue = "foreignKey".hashValue
+        for key in keyNames {
+            hashvalue = hashvalue ^ key.hashValue
+        }
+        for ref in refNames {
+            hashvalue = hashvalue ^ ref.hashValue
+        }
+        return hashvalue
+    }
+
+    static public func == (lhs: ForeignKey, rhs: ForeignKey) -> Bool {
+        // Foreign keys cannot span databases and we do not currently support temporary tables therefore checking key name and ref name sets match is sufficient to establish equality
+        if !(Set(lhs.keyNames) == Set(rhs.keyNames)) {
+            return false
+        }
+        if !(Set(lhs.refNames) == Set(rhs.refNames)) {
+            return false
+        }
+        return true
+    }
+
+    func describe(queryBuilder: QueryBuilder) -> String {
+        var append = ", FOREIGN KEY ("
+        append += keyColumns.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
+        append += ") REFERENCES "
+        append += Utils.packName(refColumns[0].table._name, queryBuilder: queryBuilder)
+        append += "("
+        append += refColumns.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
+        append += ")"
+        return append
+    }
+}

--- a/Sources/SwiftKuery/ForeignKey.swift
+++ b/Sources/SwiftKuery/ForeignKey.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-struct ForeignKey: Hashable {
+struct ForeignKey: Hashable, Buildable {
     var keyColumns: [Column]
     var refColumns: [Column]
     var keyNames: [String]
@@ -28,8 +28,8 @@ struct ForeignKey: Hashable {
         }
         keyColumns = keys
         refColumns = refs
-        keyNames = keyColumns.map { "\($0._table._name).\($0.name)"}
-        refNames = refColumns.map { "\($0._table._name).\($0.name)"}
+        keyNames = keyColumns.map { "\($0._table._name).\($0.name)" }
+        refNames = refColumns.map { "\($0._table._name).\($0.name)" }
     }
 
     static func validKey(_ keys: [Column], _ refs: [Column],_ tableName: String, _ errorString: inout String) -> Bool {
@@ -79,7 +79,7 @@ struct ForeignKey: Hashable {
         return true
     }
 
-    func describe(queryBuilder: QueryBuilder) -> String {
+    func build(queryBuilder: QueryBuilder) -> String {
         var append = ", FOREIGN KEY ("
         append += keyColumns.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
         append += ") REFERENCES "

--- a/Sources/SwiftKuery/Table.swift
+++ b/Sources/SwiftKuery/Table.swift
@@ -45,16 +45,17 @@ open class Table: Buildable {
     public private (set) var alias: String?
     
     private var primaryKey: [Column]?
-    private var foreignKeyColumns: [Column]?
-    private var foreignKeyReferences: [Column]?
     private var syntaxError = ""
-    
+
+    // An array of foreign keys for the table
+    private var foreignKeys: [ForeignKey] = []
+
     /// The name of the table to be used inside a query, i.e., either its alias (if exists)
     /// or its name.
     public var nameInQuery: String {
         return alias ?? _name
     }
-    
+
     // MARK: Initializer
     /// Initialize an instance of Table.
     public required init() {
@@ -138,42 +139,51 @@ open class Table: Buildable {
         }
         return result
     }
-    
-    /// Function that returns the SQL CREATE TABLE query as a String for this TABLE.
-    /// - Returns: A String representation of the table create statement.
-    /// - Throws: QueryError.syntaxError if statement build fails.
+
+    /**
+     Function that returns the SQL CREATE TABLE statement for this table in string fromat.
+     ### Usage Example: ###
+     In this example we define a simple table named exampleTable and then print its description
+     ```swift
+     class ExampleTable: Table {
+         let tableName = "ExampleTable"
+         let name = Column("name", String.self)
+     }
+     let examples = ExampleTable()
+     let description = try examples.description(connection: getConnection(from: postgresPool))
+     print(description)
+     // Prints CREATE TABLE ExampleTable (name text)
+     ```
+     
+     - Returns: A String representation of the table create statement.
+     - Throws: QueryError.syntaxError if statement build fails.
+    */
     public func description(connection: Connection) throws -> String {
         if syntaxError != "" {
             throw QueryError.syntaxError(syntaxError)
         }
-        
+
         let queryBuilder = connection.queryBuilder
-        
+
         var query = "CREATE TABLE " + Utils.packName(_name, queryBuilder: queryBuilder)
         query +=  " ("
-        
+
         query += try columns.map { try $0.create(queryBuilder: queryBuilder) }.joined(separator: ", ")
-        
+
         if let primaryKey = primaryKey {
             query += ", PRIMARY KEY ("
             query += primaryKey.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
             query += ")"
         }
-        
-        if let foreignKeyColumns = foreignKeyColumns, let foreignKeyReferences = foreignKeyReferences {
-            query += ", FOREIGN KEY ("
-            query += foreignKeyColumns.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
-            query += ") REFERENCES "
-            let referencedTableName = foreignKeyReferences[0].table._name
-            query += Utils.packName(referencedTableName, queryBuilder: queryBuilder) + "("
-            query += foreignKeyReferences.map { Utils.packName($0.name, queryBuilder: queryBuilder) }.joined(separator: ", ")
-            query += ")"
+
+        if !foreignKeys.isEmpty {
+            query += foreignKeys.map { $0.describe(queryBuilder: queryBuilder) }.joined(separator: "")
         }
-        
+
         query += ")"
         return query
     }
-    
+
     // MARK: Create Alias
     /**
      Function to return a copy of the current `Table` instance with the given name as its alias.
@@ -317,12 +327,12 @@ open class Table: Buildable {
     public func primaryKey(_ columns: Column...) -> Self {
         return primaryKey(columns)
     }
-    
+
     /**
-     Function to set a multiple `Column` instance, as a composite foreign key, in the `Table` instance referencing multiple column in another Table.
-     The function also validates the columns to ensure they belong to the table and do not conflict with the definition of a foreign key.
+     Function to set a multiple `Column` instance, as a composite foreign key, in the `Table` instance referencing multiple columns in another Table.
+     The function also validates the columns to ensure they belong to the table and do not conflict with the definition of an existing foreign key.
      ### Usage Example: ###
-     In this example, `Table` instances called personTable and employeeTable are created. A "personTable" foreign key is then set to be a composite of firstColumn and lastColumn, which reference firstName and surname in employeeTable.
+     In this example, `Table` instances called personTable and employeeTable are created. A composite primary key is created on "employeeTable". A "personTable" foreign key is then set to be a composite of firstColumn and lastColumn, which reference firstName and surname in employeeTable.
      ```swift
      public class EmployeeTable: Table {
          let tableName = "employeeTable"
@@ -331,54 +341,38 @@ open class Table: Buildable {
          let monthlyPay = Column("monthlyPay", Int32.self)
      }
      public class PersonTable: Table {
-        let tableName = "personTable"
-        let firstName = Column("firstName", String.self, notNull: true)
-        let lastName = Column("lastName", String.self, notNull: true)
-        let dateOfBirth = Column("toDo_completed", String.self)
+         let tableName = "personTable"
+         let firstName = Column("firstName", String.self, notNull: true)
+         let lastName = Column("lastName", String.self, notNull: true)
+         let dateOfBirth = Column("toDo_completed", String.self)
      }
      var personTable = PersonTable()
      var employeeTable = EmployeeTable()
+     employeeTable = employeeTable.primaryKey([employeeTable.firstname, employeeTable.surname])
      personTable = personTable.foreignKey([personTable.firstName, personTable.lastName], references: [employeeTable.firstName, employeeTable.surname])
      ```
-    
+
      - Parameter columns: An Array of columns that constitute the foreign key.
      - Parameter references: An Array of columns from the foreign table that are referenced by the foreign key.
      - Returns: A new instance of `Table`.
-    */
+     */
     public func foreignKey(_ columns: [Column], references: [Column]) -> Self {
-        if foreignKeyColumns != nil || foreignKeyReferences != nil {
-            syntaxError += "Conflicting definitions of foreign key. "
+        var errorString: String = ""
+        guard let newKey = ForeignKey(keys: columns, refs: references, self._name, &errorString) else {
+            syntaxError += errorString
+            return self
         }
-        else if columns.count == 0 || references.count == 0 || columns.count != references.count {
-            syntaxError += "Invalid definition of foreign key. "
-        }
-        else if !Table.columnsBelongTo(table: self, columns: columns) {
-            syntaxError += "Foreign key contains columns from another table. "
-        }
-        else if !Table.columnsBelongTo(table: references[0].table, columns: references) {
-            syntaxError += "Foreign key references columns from more than one table. "
-        }
-        else {
-            foreignKeyColumns = columns
-            foreignKeyReferences = references
+        if !foreignKeys.contains(newKey) {
+            foreignKeys.append(newKey)
         }
         return self
     }
-    
-    private static func columnsBelongTo(table: Table, columns: [Column]) -> Bool {
-        for column in columns {
-            if column.table._name != table._name {
-                return false
-            }
-        }
-        return true
-    }
-    
+
     /**
      Function to set a single `Column` instance, as a foreign key, in the `Table` instance.
-     The function also validates the column to ensure it belongs to the table and does not conflict with the definition of a foreign key.
+     The function also validates the column to ensure it belongs to the table and does not conflict with the definition of an existing foreign key.
      ### Usage Example: ###
-     In this example, `Table` instances called personTable and employeeTable are created. A "personTable" foreign key is then set to be id, which reference identifier in employeeTable.
+     In this example, `Table` instances called personTable and employeeTable are created. A "personTable" foreign key is then set to be id, which references identifier in employeeTable.
      ```swift
      public class EmployeeTable: Table {
          let identifier = Column("identifier", Int32.self, notNull: true)
@@ -386,21 +380,30 @@ open class Table: Buildable {
          let employeeBand = Column("employeeBand", String.self)
      }
      public class PersonTable: Table {
-        let tableName = "personTable"
-        let id = Column("id", Int32.self, notNull: true)
-        let firstName = Column("firstName", String.self, notNull: true)
-        let lastName = Column("lastName", String.self, notNull: true)
+         let tableName = "personTable"
+         let id = Column("id", Int32.self, notNull: true)
+         let firstName = Column("firstName", String.self, notNull: true)
+         let lastName = Column("lastName", String.self, notNull: true)
      }
      var personTable = PersonTable()
      var employeeTable = EmployeeTable()
      personTable = personTable.foreignKey(personTable.id, references: employeeTable.identifier)
      ```
-    
+
      - Parameter columns: A column that is the foreign key.
      - Parameter references: A column in the foreign table the foreign key references.
      - Returns: A new instance of `Table`.
     */
     public func foreignKey(_ column: Column, references: Column) -> Self {
         return foreignKey([column], references: [references])
+    }
+
+    private static func columnsBelongTo(table: Table, columns: [Column]) -> Bool {
+        for column in columns {
+            if column.table._name != table._name {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/Sources/SwiftKuery/Table.swift
+++ b/Sources/SwiftKuery/Table.swift
@@ -177,7 +177,7 @@ open class Table: Buildable {
         }
 
         if !foreignKeys.isEmpty {
-            query += foreignKeys.map { $0.describe(queryBuilder: queryBuilder) }.joined(separator: "")
+            query += foreignKeys.map { $0.build(queryBuilder: queryBuilder) }.joined(separator: "")
         }
 
         query += ")"

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -21,6 +21,7 @@ class TestSchema: XCTestCase {
     
     static var allTests: [(String, (TestSchema) -> () throws -> Void)] {
         return [
+            ("testMultipleForeignKeys", testMultipleForeignKeys),
             ("testCreateTable", testCreateTable),
         ]
     }
@@ -71,6 +72,71 @@ class TestSchema: XCTestCase {
         let b = Column("b")
     }
 
+    func testMultipleForeignKeys() {
+        let connection = createConnection()
+
+        var t1 = Table1()
+        var t2 = Table2()
+
+        // This tests a one to one foreign key
+        var createStmt = createTable(t1.foreignKey(t1.a, references: t2.b), connection: connection)
+        var expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a) REFERENCES table2(b))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests that multiple foreign keys can be added for the one to one case
+        createStmt = createTable(t1.foreignKey(t1.a, references: t2.b).foreignKey(t1.b, references: t2.a), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a) REFERENCES table2(b), FOREIGN KEY (b) REFERENCES table2(a))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests that duplicate foreign keys are ignored for the one to one case
+        createStmt = createTable(t1.foreignKey(t1.a, references: t2.b).foreignKey(t1.a, references: t2.b), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a) REFERENCES table2(b))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests a many to many foreign key (composite keys do not support different reference tables)
+        createStmt = createTable(t1.foreignKey([t1.a, t1.b], references: [t2.b, t2.a]), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a, b) REFERENCES table2(b, a))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests mulitple foreign keys can be added for the many to many case
+        createStmt = createTable(t1.foreignKey([t1.a, t1.b], references: [t2.b, t2.a]).foreignKey([t1.a, t1.c], references: [t2.b, t2.a]), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a, b) REFERENCES table2(b, a), FOREIGN KEY (a, c) REFERENCES table2(b, a))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests that duplicate foreign keys are ignored for the many to many case
+        createStmt = createTable(t1.foreignKey([t1.a, t1.b], references: [t2.b, t2.a]).foreignKey([t1.a, t1.b], references: [t2.b, t2.a]), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a, b) REFERENCES table2(b, a))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        // Need to reset tables
+        t1 = Table1()
+        t2 = Table2()
+
+        // This tests that duplicate foreign keys are ignored for the many to many case irrespective of key ordering
+        createStmt = createTable(t1.foreignKey([t1.a, t1.b], references: [t2.b, t2.a]).foreignKey([t1.b, t1.a], references: [t2.b, t2.a]), connection: connection)
+        expectedCreateStmt = "CREATE TABLE table1 (a text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", b integer AUTO_INCREMENT, c double DEFAULT 4.95 CHECK (c > 0), FOREIGN KEY (a, b) REFERENCES table2(b, a))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+    }
     
     func testCreateTable () {
         let connection = createConnection()
@@ -108,16 +174,17 @@ class TestSchema: XCTestCase {
         expectedError = "Primary key contains columns from another table. "
         XCTAssertEqual(error, expectedError)
         
+        t1 = Table1()
         t4 = Table4()
-        error = createBadTable(t4.foreignKey(t4.b, references: t2.a).foreignKey(t4.a, references: t2.b), connection: connection)
-        expectedError = "Conflicting definitions of foreign key. "
+        error = createBadTable(t4.foreignKey(t1.b, references: t1.c), connection: connection)
+        expectedError = "Foreign key contains columns from another table. "
         XCTAssertEqual(error, expectedError)
 
         t4 = Table4()
         error = createBadTable(t4.foreignKey([t4.b, t4.a], references: [t2.a, t1.a]), connection: connection)
         expectedError = "Foreign key references columns from more than one table. "
         XCTAssertEqual(error, expectedError)
-
+        
         t4 = Table4()
         error = createBadTable(t4.foreignKey([t4.b, t4.a], references: [t2.a]), connection: connection)
         expectedError = "Invalid definition of foreign key. "


### PR DESCRIPTION
This PR improves Swift-Kuery's support for foreign keys.

With the changes it is now possible to specify multiple foreign keys on a table.

It should be noted that a user will still need to ensure their tables are built correctly to allow the use of composite keys.