### PR TITLE
Handle failure of ConnectionPool connection generator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,14 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target defines a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftKuery",
-            dependencies: []),
+            dependencies: ["LoggerAPI"]),
         .testTarget(
             name: "SwiftKueryTests",
             dependencies: ["SwiftKuery"]),

--- a/Sources/SwiftKuery/ConnectionPool.swift
+++ b/Sources/SwiftKuery/ConnectionPool.swift
@@ -20,6 +20,7 @@ import Dispatch
 #else
     import Darwin
 #endif
+import LoggerAPI
 
 // MARK: ConnectionPool
 
@@ -112,7 +113,14 @@ public class ConnectionPool {
             if let item = generator() {
                 pool.append(item)
             }
-            else {} // TODO: Handle generation failure.
+            else {}
+        }
+        // Handle generation failure
+        if pool.count < capacity {
+            Log.warning("Connection generation failed (\(pool.count) of \(capacity) connections created")
+            // Ensure capacity and pool.count are in sync. This enables us to recover
+            // in the future if the database becomes reachable again.
+            capacity = pool.count
         }
     }
     


### PR DESCRIPTION
Follows on from #128 and #103.

When the ConnectionPool is first created but the database is unreachable, it can fail to generate connections (if the generator has been written in such a way that only 'good' connections are returned).

In this scenario, the pool's current `capacity` (the initial number of connections we try to generate) is out of sync with the actual size of the pool (represented by `pool.count`), which is normally only the case when connections have been vended from the pool and not yet returned.  We cannot recover from this situation, as we will not attempt to grow the pool, as its capacity is (apparently) not zero.

This fix ensures that the initial capacity and pool.count are in sync immediately after connection generation.  We will attempt to generate a new connection each time we are asked to vend one, and this will continue to fail (and the capacity remain zero) while the database is unreachable.  At some future time, if the database were to become reachable again, we will be at zero capacity and begin to grow the pool, as per #128.

### Testing
I've verified that this resolves the ability to grow the pool after initial failure using a local project with a Postgres database and a connection generator function that only produces connections if they successfully `connect()`.