### PR TITLE
Make the MID function substitutable by Kuery implementations

### DIFF
--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -71,6 +71,8 @@ public class QueryBuilder {
         case len
         /// The SQL NOW scalar function to return the current date and time.
         case now
+        /// The SQL MID scalar function to return a portion of a string.
+        case mid
         /// The marker for the query numbered parameters.
         case numberedParameter
         /// The marker for the query named parameters.
@@ -150,6 +152,7 @@ public class QueryBuilder {
         substitutions[QuerySubstitutionNames.lcase.rawValue] = "LCASE"
         substitutions[QuerySubstitutionNames.len.rawValue] = "LEN"
         substitutions[QuerySubstitutionNames.now.rawValue] = "NOW()"
+        substitutions[QuerySubstitutionNames.mid.rawValue] = "MID"
         substitutions[QuerySubstitutionNames.numberedParameter.rawValue] = "?"
         substitutions[QuerySubstitutionNames.namedParameter.rawValue] = "@"
         substitutions[QuerySubstitutionNames.booleanTrue.rawValue] = "true"

--- a/Sources/SwiftKuery/ScalarColumnExpression.swift
+++ b/Sources/SwiftKuery/ScalarColumnExpression.swift
@@ -73,7 +73,7 @@ public struct ScalarColumnExpression: Field {
             case .round(let field, let decimal):
                 return try "ROUND(" + field.build(queryBuilder: queryBuilder) + ", \(decimal))"
             case .mid(let field, let start, let length):
-                return try "MID(" + field.build(queryBuilder: queryBuilder) + ", \(start), \(length))"
+                return try queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.mid.rawValue] + "(" + field.build(queryBuilder: queryBuilder) + ", \(start), \(length))"
             case .len(let field):
                 return try "LEN(" + field.build(queryBuilder: queryBuilder) + ")"
             }


### PR DESCRIPTION
The `MID` function is a synonym for `SUBSTRING` on PostgreSQL and MySQL, but on SQLite, no synonym exists for its equivalent `SUBSTR` function. We need to do a substitution for it, but we can't since it's not currently substitutable. This PR resolves that; once in place, we'll be able to put the substitution in place in Swift-Kuery-SQLite.