### PR TITLE
Set semaphore in correct location

### DIFF
--- a/Sources/SwiftKuery/ConnectionPool.swift
+++ b/Sources/SwiftKuery/ConnectionPool.swift
@@ -108,13 +108,13 @@ public class ConnectionPool {
         timeoutNs = Int64(timeout) * 1000000  // Convert ms to ns
         generator = connectionGenerator
         releaser = connectionReleaser
-        semaphore = DispatchSemaphore(value: capacity)
         for _ in 0 ..< capacity {
             if let item = generator() {
                 pool.append(item)
             }
             else {}
         }
+        semaphore = DispatchSemaphore(value: pool.count)
         // Handle generation failure
         if pool.count < capacity {
             Log.warning("Connection generation failed (\(pool.count) of \(capacity) connections created")


### PR DESCRIPTION
When the Connection pool is initialised the `pool.count`, `capacity` and `semaphore` should all be in sync. 

In the current implementation we set the `semaphore` to the `capacity` size, but then we compare the `pool.count` size to the `capacity` size and if `pool.count` is less than `capacity` we make `capacity` equal to `pool.count`. Doing this would then bring the `semaphore` out of sync. 

With this change, we will now set the `semaphore` using the `pool.count` value and we only set this after we've finished calculating the `pool.count` value so it can't change during the initialisation. 