### PR TITLE
Allow implementations to override how primary key is defined

### DIFF
--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -210,7 +210,13 @@ public class Column: Field, IndexColumn {
         }
 
         if isPrimaryKey {
-            result += " PRIMARY KEY"
+            if let createSinglePrimaryKey = queryBuilder.createSinglePrimaryKey {
+                let pkString = createSinglePrimaryKey(typeString, autoIncrement)
+                result += pkString
+            }
+            else {
+                result += " PRIMARY KEY"
+            }
         }
         if isNotNullable {
             result += " NOT NULL"

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -120,6 +120,11 @@ public class QueryBuilder {
     /// A function to create an autoincrement expression for the column, based on the column type.
     public let createAutoIncrement: ((String, Bool) -> String)?
 
+    /// A function to create a primary key expression for the column based on
+    /// column type and auto-increment status. Return value should have a space
+    /// as the first character; e.g. " PRIMARY KEY" (or can be empty).
+    public let createSinglePrimaryKey: ((String, Bool) -> String)?
+
     /// An indication whether the drop index syntax requires the `ON table.name` clause.
     public let dropIndexRequiresOnTableName: Bool
 
@@ -145,7 +150,7 @@ public class QueryBuilder {
      - Parameter dateFormatter: DateFormatter to convert between date and string instances.
     */
     public init(addNumbersToParameters: Bool = true, firstParameterIndex: Int = 1, anyOnSubquerySupported: Bool = true,
-                withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String, Bool) -> String)? = nil,
+                withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String, Bool) -> String)? = nil, createSinglePrimaryKey: ((String, Bool) -> String)? = nil,
                 dropIndexRequiresOnTableName: Bool = false, dateFormatter: DateFormatter? = nil) {
         substitutions = Array(repeating: "", count: QuerySubstitutionNames.namesCount.rawValue)
         substitutions[QuerySubstitutionNames.ucase.rawValue] = "UCASE"
@@ -171,6 +176,7 @@ public class QueryBuilder {
         self.withDeleteRequiresUsing = withDeleteRequiresUsing
         self.withUpdateRequiresFrom = withUpdateRequiresFrom
         self.createAutoIncrement = createAutoIncrement
+        self.createSinglePrimaryKey = createSinglePrimaryKey
         self.dropIndexRequiresOnTableName = dropIndexRequiresOnTableName
         self.dateFormatter = dateFormatter
     }


### PR DESCRIPTION
…similarly to how a column can be defined as auto-increment can be overridden.

The reason this is (probably) necessary is described in [this issue for Swift-Kuery-SQLite](https://github.com/IBM-Swift/Swift-Kuery-SQLite/issues/18), for which defining auto-increment columns is currently broken in a somewhat comical way which probably can't be fixed without hacking the core Swift-Kuery project like this.

Possibly in the future, both this and the auto-increment function can probably be replaced by a single function which receives the whole column definition and builds the query itself rather than going back and forth between Kuery and the implementation. (Based on a little bit of research, a hypothetical SQL Server implementation would need to implement both of these current methods as well.)

There is probably a small speed impact to this change, but getting auto-incrementation working in SQLite is worth it IMO.

I already have a [tested and working change for the SQLite implementation](https://github.com/NocturnalSolutions/Swift-Kuery-SQLite/commit/10b136663da4071750451cda9efd6a3716eae19a) ready to create a PR for as soon as this one lands.