### PR TITLE
Build Column descriptions in the plugins

### DIFF
--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -183,49 +183,8 @@ public class Column: Field, IndexColumn {
      - Throws: QueryError.syntaxError if column creation fails.
     */
     public func create(queryBuilder: QueryBuilder) throws -> String {
-        guard let type = type else {
-            throw QueryError.syntaxError("Column type not set for column \(name). ")
-        }
-        
-        var result = Utils.packName(name, queryBuilder: queryBuilder) + " "
-        
-        var typeString = type.create(queryBuilder: queryBuilder)
-        if let length = length {
-            typeString += "(\(length))"
-        }
-        if autoIncrement {
-            if let createAutoIncrement = queryBuilder.createAutoIncrement {
-                let autoIncrementString = createAutoIncrement(typeString, isPrimaryKey)
-                guard autoIncrementString != "" else {
-                    throw QueryError.syntaxError("Invalid autoincrement for column \(name). ")
-                }
-                result += autoIncrementString
-            }
-            else {
-                result += typeString + " AUTO_INCREMENT"
-            }
-        }
-        else {
-            result += typeString
-        }
-
-        if isPrimaryKey {
-            result += " PRIMARY KEY"
-        }
-        if isNotNullable {
-            result += " NOT NULL"
-        }
-        if isUnique {
-            result += " UNIQUE"
-        }
-        if let defaultValue = defaultValue {
-            result += " DEFAULT " + Utils.packType(defaultValue)
-        }
-        if let checkExpression = checkExpression {
-            result += checkExpression.contains(name) ? " CHECK (" + checkExpression.replacingOccurrences(of: name, with: "\"\(name)\"") + ")" : " CHECK (" + checkExpression + ")"
-        }
-        if let collate = collate {
-            result += " COLLATE \"" + collate + "\""
+        guard let result = queryBuilder.columnBuilder.buildColumn(for: self) else {
+            throw QueryError.syntaxError("Invalid column attributes for column \(name). ")
         }
         return result
     }

--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -183,7 +183,7 @@ public class Column: Field, IndexColumn {
      - Throws: QueryError.syntaxError if column creation fails.
     */
     public func create(queryBuilder: QueryBuilder) throws -> String {
-        guard let result = queryBuilder.columnBuilder.buildColumn(for: self) else {
+        guard let result = queryBuilder.columnBuilder.buildColumn(for: self, using: queryBuilder) else {
             throw QueryError.syntaxError("Invalid column attributes for column \(name). ")
         }
         return result

--- a/Sources/SwiftKuery/ColumnCreator.swift
+++ b/Sources/SwiftKuery/ColumnCreator.swift
@@ -1,0 +1,29 @@
+/**
+ Copyright IBM Corporation 2018
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+// MARK: ColumnCreator protocol
+
+/// A protocol defining functions database plugins must implement to build a string representation of a Column
+public protocol ColumnCreator {
+
+    /// Build a string representation of the column
+    ///
+    /// - Parameter column: The column being built
+    /// - Returns: A string representation of the column for the implementing database or nil if it cannot be built
+    func buildColumn(for column: Column) -> String?
+}

--- a/Sources/SwiftKuery/ColumnCreator.swift
+++ b/Sources/SwiftKuery/ColumnCreator.swift
@@ -25,5 +25,5 @@ public protocol ColumnCreator {
     ///
     /// - Parameter column: The column being built
     /// - Returns: A string representation of the column for the implementing database or nil if it cannot be built
-    func buildColumn(for column: Column) -> String?
+    func buildColumn(for column: Column, using queryBuilder: QueryBuilder) -> String?
 }

--- a/Sources/SwiftKuery/ConnectionPoolConnection.swift
+++ b/Sources/SwiftKuery/ConnectionPoolConnection.swift
@@ -343,7 +343,7 @@ public class ConnectionPoolConnection: Connection {
 }
 
 public class DummyColumBuilder : ColumnCreator {
-    public func buildColumn(for column: Column) -> String? {
+    public func buildColumn(for column: Column, using queryBuilder: QueryBuilder) -> String? {
         return nil
     }
 }

--- a/Sources/SwiftKuery/ConnectionPoolConnection.swift
+++ b/Sources/SwiftKuery/ConnectionPoolConnection.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class ConnectionPoolConnection: Connection {
     // MARK: QueryBuilder
     /// The `QueryBuilder` with connection specific substitutions.
     public var queryBuilder: QueryBuilder {
-        return connection?.queryBuilder ?? QueryBuilder()
+        return connection?.queryBuilder ?? QueryBuilder(columnBuilder: DummyColumBuilder())
     }
 
     init(connection: Connection, pool: ConnectionPool) {
@@ -339,5 +339,11 @@ public class ConnectionPoolConnection: Connection {
             return
         }
         connection.release(savepoint: savepoint, onCompletion: onCompletion)
+    }
+}
+
+public class DummyColumBuilder : ColumnCreator {
+    public func buildColumn(for column: Column) -> String? {
+        return nil
     }
 }

--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -116,9 +116,9 @@ public class QueryBuilder {
     
     /// An indication whether an `UPDATE` query should use the `FROM` clause for tables in `WITH` clause.
     public let withUpdateRequiresFrom: Bool
-    
-    /// A function to create an autoincrement expression for the column, based on the column type.
-    public let createAutoIncrement: ((String, Bool) -> String)?
+
+    /// An implementer of the ColumnCreator protocol that provides methods to build a string representation of a column.
+    public let columnBuilder: ColumnCreator
 
     /// An indication whether the drop index syntax requires the `ON table.name` clause.
     public let dropIndexRequiresOnTableName: Bool
@@ -145,7 +145,7 @@ public class QueryBuilder {
      - Parameter dateFormatter: DateFormatter to convert between date and string instances.
     */
     public init(addNumbersToParameters: Bool = true, firstParameterIndex: Int = 1, anyOnSubquerySupported: Bool = true,
-                withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String, Bool) -> String)? = nil,
+                withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, columnBuilder: ColumnCreator,
                 dropIndexRequiresOnTableName: Bool = false, dateFormatter: DateFormatter? = nil) {
         substitutions = Array(repeating: "", count: QuerySubstitutionNames.namesCount.rawValue)
         substitutions[QuerySubstitutionNames.ucase.rawValue] = "UCASE"
@@ -170,7 +170,7 @@ public class QueryBuilder {
         self.firstParameterIndex = firstParameterIndex
         self.withDeleteRequiresUsing = withDeleteRequiresUsing
         self.withUpdateRequiresFrom = withUpdateRequiresFrom
-        self.createAutoIncrement = createAutoIncrement
+        self.columnBuilder = columnBuilder
         self.dropIndexRequiresOnTableName = dropIndexRequiresOnTableName
         self.dateFormatter = dateFormatter
     }

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -202,13 +202,13 @@ class TestSchema: XCTestCase {
 
         let t5 = Table5()
         error = createBadTable(t5, connection: connection)
-        expectedError = "Column type not set for column b. "
+        expectedError = "Invalid column attributes for column b. "
         XCTAssertEqual(error, expectedError)
 
         t1 = Table1()
         let connectionWithAutoIncrement = createConnection(createAutoIncrement: createAutoIncrement)
         createStmt = createTable(t1, connection: connectionWithAutoIncrement)
-        expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" auto_increment, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
+        expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
     


### PR DESCRIPTION
This PR updates query to offload the building of column descriptions the an underlying DB plugin. This has the advantage of being able to handle plugin specific behaviors without conditional logic in base Kuery.