### PR TITLE
Support overriding table names during initialization

### DIFF
--- a/Sources/SwiftKuery/Table.swift
+++ b/Sources/SwiftKuery/Table.swift
@@ -58,7 +58,8 @@ open class Table: Buildable {
 
     // MARK: Initializer
     /// Initialize an instance of Table.
-    public required init() {
+    /// - Parameter name: The name of the table (Optional).
+    public required init(name: String? = nil) {
         columns = [Column]()
         let mirror = Mirror(reflecting: self)
         for child in mirror.children {
@@ -68,11 +69,15 @@ open class Table: Buildable {
                 if column.isPrimaryKey {
                     columnsWithPrimaryKeyProperty += 1
                 }
-            }
-            else if let label = child.label, label == "tableName" {
+            } else if let label = child.label, label == "tableName", name == nil {
                 _name = child.value as! String
             }
         }
+
+        if let name = name {
+            _name = name
+        }
+
         verifyTableProperties()
     }
 

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -137,25 +137,30 @@ class TestSchema: XCTestCase {
         expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0), FOREIGN KEY (\"a\", \"b\") REFERENCES \"table2\"(\"b\", \"a\"))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
-    
+
     func testCreateTable () {
         let connection = createConnection()
-        
+
         var t1 = Table1()
         var createStmt = createTable(t1, connection: connection)
         var expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
-        
+
+        t1 = Table1(name: "foobar")
+        createStmt = createTable(t1, connection: connection)
+        expectedCreateStmt = "CREATE TABLE \"foobar\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
         let t2 = Table2()
         createStmt = createTable(t2, connection: connection)
         expectedCreateStmt = "CREATE TABLE \"table2\" (\"a\" varchar, \"b\" varchar(20) UNIQUE, \"c\" smallint NOT NULL, \"d\" integer, \"e\" date, \"f\" timestamp, \"g\" mySQLType(15))"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
-        
+
         let t3 = Table3()
         var error = createBadTable(t3, connection: connection)
         var expectedError = "Conflicting definitions of primary key. "
         XCTAssertEqual(error, expectedError)
-        
+
         error = createBadTable(t1.primaryKey(t1.b, t1.c), connection: connection)
         expectedError = "Conflicting definitions of primary key. "
         XCTAssertEqual(error, expectedError)


### PR DESCRIPTION
Mirroring the children and extracting the table name and columns is pretty slick. But, with this, it's not possible to reuse the same table elsewhere with a different name.

Also, since `Column` stores a `weak var` of the associated table, we can't do this either:

```swift
let table1 = SomeTable()
let table2 = SomeTable(tableName: "new name", columns: table1.columns)
```

... since that will change the columns of `table1` to point to `table2`. So, I've added an optional parameter to the `Table` initializer.