### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -44,6 +49,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/SwiftKuery/ColumnAndExpressions_Extensions.swift
+++ b/Sources/SwiftKuery/ColumnAndExpressions_Extensions.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public extension ScalarColumnExpression {
+extension ScalarColumnExpression {
     /// Create a `Filter` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.
@@ -446,7 +446,7 @@ public extension ScalarColumnExpression {
 
 }
 
-public extension Column {
+extension Column {
     /// Create a `Filter` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.
@@ -875,7 +875,7 @@ public extension Column {
 
 }
 
-public extension AggregateColumnExpression {
+extension AggregateColumnExpression {
     /// Create a `Having` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.
@@ -1304,7 +1304,7 @@ public extension AggregateColumnExpression {
 
 }
 
-public extension Column {
+extension Column {
     /// Create a `Having` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.

--- a/Sources/SwiftKuery/ConditionalClause.swift
+++ b/Sources/SwiftKuery/ConditionalClause.swift
@@ -38,7 +38,7 @@ public protocol ConditionalClause: Buildable {
 }
 
 /// An extension of `ConditionalClause` with implementation of `Buildable` protocol.
-public extension ConditionalClause {
+extension ConditionalClause {
     /// Build the clause using `QueryBuilder`.
     ///
     /// - Parameter queryBuilder: The QueryBuilder to use.

--- a/Sources/SwiftKuery/Field.swift
+++ b/Sources/SwiftKuery/Field.swift
@@ -30,7 +30,7 @@ public protocol Field: Buildable {
     func `as`(_ newName: String) -> Field
 }
 
-public extension Field {
+extension Field {
     /// Add an alias to the field, i.e., implement the SQL AS operator.
     ///
     /// - Parameter newName: A String containing the alias for the field.

--- a/Sources/SwiftKuery/FilterAndHaving_Extensions.swift
+++ b/Sources/SwiftKuery/FilterAndHaving_Extensions.swift
@@ -14,7 +14,7 @@
 * limitations under the License.
 **/
 
-public extension Filter {
+extension Filter {
 
     /// Create a `Filter` clause using the isNull operator.
     ///
@@ -30,7 +30,7 @@ public extension Filter {
         return Filter(lhs: .clause(self), condition: .isNotNull)
     }
 }
-public extension Having {
+extension Having {
 
     /// Create a `Having` clause using the isNull operator.
     ///

--- a/Sources/SwiftKuery/Query.swift
+++ b/Sources/SwiftKuery/Query.swift
@@ -20,7 +20,7 @@
 public protocol Query: Buildable {
 }
 
-public extension Query {
+extension Query {
     /// Execute the query.
     ///
     /// - Parameter connection: The plugin that implements the Connection protocol and executes the query.

--- a/Sources/SwiftKuery/ResultSet.swift
+++ b/Sources/SwiftKuery/ResultSet.swift
@@ -20,7 +20,7 @@
 public class ResultSet {
     private var resultFetcher: ResultFetcher
     
-    internal (set) var connection: Connection? = nil
+    var connection: Connection? = nil
 
     /// The query result as a Sequence of rows. This API is blocking.
     public private (set) var rows: RowSequence

--- a/Sources/SwiftKuery/ScalarColumnExpression.swift
+++ b/Sources/SwiftKuery/ScalarColumnExpression.swift
@@ -45,7 +45,7 @@ public struct ScalarColumnExpression: Field {
     /// An enumeration of the supported scalar functions that can applied on a column.
     public enum ScalarFunction: Buildable {
         /// The SQL NOW function.
-        case now()
+        case now
         /// The SQL UCASE function.
         case ucase(field: Field)
         /// The SQL LCASE function.
@@ -87,7 +87,7 @@ public struct ScalarColumnExpression: Field {
 ///
 /// - Returns: An instance of `ScalarColumnExpression`.
 public func now() -> ScalarColumnExpression {
-    return ScalarColumnExpression(.now())
+    return ScalarColumnExpression(.now)
 }
 
 /// Create a `ScalarColumnExpression` using the LEN function.

--- a/Sources/SwiftKuery/SpecialOperators_Extensions.swift
+++ b/Sources/SwiftKuery/SpecialOperators_Extensions.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public extension Bool {
+extension Bool {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -244,7 +244,7 @@ public extension Bool {
     }
 }
 
-public extension String {
+extension String {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -471,7 +471,7 @@ public extension String {
     }
 }
 
-public extension Int {
+extension Int {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -698,7 +698,7 @@ public extension Int {
     }
 }
 
-public extension Float {
+extension Float {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -925,7 +925,7 @@ public extension Float {
     }
 }
 
-public extension Double {
+extension Double {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -1152,7 +1152,7 @@ public extension Double {
     }
 }
 
-public extension Parameter {
+extension Parameter {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -1267,7 +1267,7 @@ public extension Parameter {
     }
 }
 
-public extension Date {
+extension Date {
 
     /// Create a `Filter` clause using the `in` operator.
     ///
@@ -1493,7 +1493,7 @@ public extension Date {
         return Having(lhs: .date(self), rhs: .arrayOfParameter(array), condition: .notBetween)
     }
 }
-public extension String {
+extension String {
     /// Create a `Filter` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.
@@ -1559,7 +1559,7 @@ public extension String {
     }
 
 }
-public extension Parameter {
+extension Parameter {
     /// Create a `Filter` clause using the like operator.
     ///
     /// - Parameter pattern: The pattern to use in the like expression.

--- a/Sources/SwiftKuery/Subqueries_GlobalFunctionsAndExtensions.swift
+++ b/Sources/SwiftKuery/Subqueries_GlobalFunctionsAndExtensions.swift
@@ -1072,7 +1072,7 @@ public func !=(lhs: Bool, rhs: Predicate<Having,AggregateColumnExpression>) -> H
     return Having(lhs: .bool(lhs), rhs: rhs, condition: .notEqual)
 }
 
-public extension ScalarColumnExpression {
+extension ScalarColumnExpression {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1090,7 +1090,7 @@ public extension ScalarColumnExpression {
         return Filter(lhs: .columnExpression(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension String {
+extension String {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1108,7 +1108,7 @@ public extension String {
         return Filter(lhs: .string(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Column {
+extension Column {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1126,7 +1126,7 @@ public extension Column {
         return Filter(lhs: .column(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Int {
+extension Int {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1144,7 +1144,7 @@ public extension Int {
         return Filter(lhs: .int(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Float {
+extension Float {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1162,7 +1162,7 @@ public extension Float {
         return Filter(lhs: .float(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Double {
+extension Double {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1180,7 +1180,7 @@ public extension Double {
         return Filter(lhs: .double(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Parameter {
+extension Parameter {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1198,7 +1198,7 @@ public extension Parameter {
         return Filter(lhs: .parameter(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Bool {
+extension Bool {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1216,7 +1216,7 @@ public extension Bool {
         return Filter(lhs: .bool(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Date {
+extension Date {
 
     /// Create a `Filter` clause using the `in` operator for subquery.
     ///
@@ -1234,7 +1234,7 @@ public extension Date {
         return Filter(lhs: .date(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension AggregateColumnExpression {
+extension AggregateColumnExpression {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1252,7 +1252,7 @@ public extension AggregateColumnExpression {
         return Having(lhs: .columnExpression(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension String {
+extension String {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1270,7 +1270,7 @@ public extension String {
         return Having(lhs: .string(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Column {
+extension Column {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1288,7 +1288,7 @@ public extension Column {
         return Having(lhs: .column(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Int {
+extension Int {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1306,7 +1306,7 @@ public extension Int {
         return Having(lhs: .int(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Float {
+extension Float {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1324,7 +1324,7 @@ public extension Float {
         return Having(lhs: .float(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Double {
+extension Double {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1342,7 +1342,7 @@ public extension Double {
         return Having(lhs: .double(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Parameter {
+extension Parameter {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1360,7 +1360,7 @@ public extension Parameter {
         return Having(lhs: .parameter(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Bool {
+extension Bool {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///
@@ -1378,7 +1378,7 @@ public extension Bool {
         return Having(lhs: .bool(self), rhs: .select(query), condition: .notIn)
     }
 }
-public extension Date {
+extension Date {
 
     /// Create a `Having` clause using the `in` operator for subquery.
     ///


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Resolves a number of Swift 5 compilation warnings:
- removal of redundant `public` default modifier on extensions (whose members are all explicitly declared public),
- removal of a redundant `internal (set)` declaration on an internal property,
- removal of an empty associated value on an enum.