### PR TITLE
adds support for inserting null values with columns

### DIFF
--- a/Sources/SwiftKuery/QueryBuilder.swift
+++ b/Sources/SwiftKuery/QueryBuilder.swift
@@ -95,6 +95,8 @@ public class QueryBuilder {
         case char
         /// The database type that corresponds to UUID. Accepts a string representation of UUID.
         case uuid
+        /// The database type that corresponds to NULL
+        case null
 
         /// Last case, add new values before it.
         case namesCount
@@ -164,6 +166,7 @@ public class QueryBuilder {
         substitutions[QuerySubstitutionNames.double.rawValue] = "double"
         substitutions[QuerySubstitutionNames.char.rawValue] = "char"
         substitutions[QuerySubstitutionNames.uuid.rawValue] = "varchar(36)"
+        substitutions[QuerySubstitutionNames.null.rawValue] = "NULL"
 
         self.addNumbersToParameters = addNumbersToParameters
         self.anyOnSubquerySupported = anyOnSubquerySupported

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -44,7 +44,8 @@ struct Utils {
             }
             return "'\(String(describing: value))'"
         default:
-            return String(describing: item)
+            let val = String(describing: item)
+            return val == "nil" ? queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.null.rawValue] : val
         }
     }
         

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -66,7 +66,8 @@ class TestInsert: XCTestCase {
         query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', 17) RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
-        i = Insert(into: t, columns: [t.a, t.b], values: ["banana", nil])
+        let optionalString: String? = nil
+        i = Insert(into: t, columns: [t.a, t.b], values: ["banana", optionalString as Any])
             .suffix("RETURNING *")
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', NULL) RETURNING *"

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -66,6 +66,12 @@ class TestInsert: XCTestCase {
         query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', 17) RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
+        i = Insert(into: t, columns: [t.a, t.b], values: ["banana", nil])
+            .suffix("RETURNING *")
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', NULL) RETURNING *"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
         i = Insert(into: t, rows: [["apple", 17], ["banana", -7], ["banana", 27]])
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO \"tableInsert\" VALUES ('apple', 17), ('banana', -7), ('banana', 27)"


### PR DESCRIPTION
Currently, to insert a null value (from a nil/optional value), you must do an insert where you specify every column and a value for every column in the insert (so you cannot do a partial insert). This creates overhead each time a migration alters the table structure.

This change introduces support for a partial insert with optional values.