### PR TITLE
Nil support

### DIFF
--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+import Foundation
 // MARK: Column
 
 /**
@@ -32,6 +33,10 @@ In this example, a person `Table` class, containing three instances of the `Colu
  ```
  */
 public class Column: Field, IndexColumn {
+
+    // A value substituted as the default value for all column definitions. If not overidden equates to NULL.
+    private static let globalDefault: Any? = UUID.init()
+
     // MARK: Column Parameters
     /// The name of the column.
     public let name: String
@@ -97,7 +102,7 @@ public class Column: Field, IndexColumn {
      - Parameter check: The expression to check for values inserted into the column. Defaults to nil.
      - Parameter collate: The collation rule for the column. Defaults to nil.
      */
-    public init(_ name: String, _ type: SQLDataType.Type? = nil, length: Int? = nil, autoIncrement: Bool = false, primaryKey: Bool = false, notNull: Bool = false, unique: Bool = false, defaultValue: Any? = nil, check: String? = nil, collate: String? = nil) {
+    public init(_ name: String, _ type: SQLDataType.Type? = nil, length: Int? = nil, autoIncrement: Bool = false, primaryKey: Bool = false, notNull: Bool = false, unique: Bool = false, defaultValue: Any? = Column.getDefaultVal(), check: String? = nil, collate: String? = nil) {
         self.name = name
         self.type = type
         self.length = length
@@ -108,6 +113,13 @@ public class Column: Field, IndexColumn {
         self.defaultValue = defaultValue
         self.checkExpression = check
         self.collate = collate
+    }
+
+    /**
+     Global static func that returns the global default identifier value for all columns
+    */
+    public static func getDefaultVal() -> Any? {
+        return globalDefault
     }
     
     //MARK: Column Decription Functions

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -96,6 +96,14 @@ public struct Insert: Query {
     /// Initialize an instance of Insert.
     ///
     /// - Parameter into: The table to insert rows.
+    /// - Parameter values: An array of values (the row) to insert.
+    public init(into table: Table, values: [Any], returnID: Bool=false) {
+        self.init(into: table, columns: nil, values: values, returnID: returnID)
+    }
+
+    /// Initialize an instance of Insert.
+    ///
+    /// - Parameter into: The table to insert rows.
     /// - Parameter valueTuples: An array of (column, value) pairs to insert.
     public init(into table: Table, valueTuples: [(Column, Any?)], returnID: Bool=false) {
         var columnsArray = Array<Column>()

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -25,7 +25,7 @@ public struct Insert: Query {
     public let columns: [Column]?
     
     /// An array of rows (values to insert in each row).
-    public private (set) var values: [[Any]]?
+    public private (set) var values: [[Any?]]?
     
     /// A String with a clause to be appended to the end of the query.
     public private (set) var suffix: QuerySuffixProtocol?
@@ -46,9 +46,9 @@ public struct Insert: Query {
     /// - Parameter into: The table to insert rows.
     /// - Parameter columns: An optional array of columns to insert. If nil, values of all the columns have to be provided.
     /// - Parameter values: An array containg the row to insert.
-    public init(into table: Table, columns: [Column]?, values: [Any], returnID: Bool=false) {
+    public init(into table: Table, columns: [Column]?, values: [Any?], returnID: Bool=false) {
         self.columns = columns
-        var valuesToInsert = [[Any]]()
+        var valuesToInsert = [[Any?]]()
         valuesToInsert.append(values)
         self.values = valuesToInsert
         self.table = table
@@ -63,7 +63,7 @@ public struct Insert: Query {
     /// - Parameter into: The table to insert rows.
     /// - Parameter columns: An optional array of columns to insert. If not specified, values of all the columns have to be provided.
     /// - Parameter values: An array of rows (values to insert in each row).
-    public init(into table: Table, columns: [Column]?=nil, rows: [[Any]], returnID: Bool=false) {
+    public init(into table: Table, columns: [Column]?=nil, rows: [[Any?]], returnID: Bool=false) {
         self.columns = columns
         self.values = rows
         self.table = table
@@ -81,7 +81,7 @@ public struct Insert: Query {
     ///
     /// - Parameter into: The table to insert rows.
     /// - Parameter values: A list of values (the row) to insert.
-    public init(into table: Table, values: Any..., returnID: Bool=false) {
+    public init(into table: Table, values: Any?..., returnID: Bool=false) {
         self.init(into: table, columns: nil, values: values, returnID: returnID)
     }
     
@@ -89,7 +89,7 @@ public struct Insert: Query {
     ///
     /// - Parameter into: The table to insert rows.
     /// - Parameter values: An array of values (the row) to insert.
-    public init(into table: Table, values: [Any], returnID: Bool=false) {
+    public init(into table: Table, values: [Any?], returnID: Bool=false) {
         self.init(into: table, columns: nil, values: values, returnID: returnID)
     }
 
@@ -97,9 +97,9 @@ public struct Insert: Query {
     ///
     /// - Parameter into: The table to insert rows.
     /// - Parameter valueTuples: An array of (column, value) pairs to insert.
-    public init(into table: Table, valueTuples: [(Column, Any)], returnID: Bool=false) {
+    public init(into table: Table, valueTuples: [(Column, Any?)], returnID: Bool=false) {
         var columnsArray = Array<Column>()
-        var valuesArray = Array<Any>()
+        var valuesArray = Array<Any?>()
         for (column, value) in valueTuples {
             columnsArray.append(column)
             valuesArray.append(value)
@@ -111,7 +111,7 @@ public struct Insert: Query {
     ///
     /// - Parameter into: The table to insert rows.
     /// - Parameter valueTuples: A list of (column, value) pairs to insert.
-    public init(into table: Table, valueTuples: (Column, Any)..., returnID: Bool=false) {
+    public init(into table: Table, valueTuples: (Column, Any?)..., returnID: Bool=false) {
         self.init(into: table, valueTuples: valueTuples, returnID: returnID)
     }
 

--- a/Sources/SwiftKuery/Insert.swift
+++ b/Sources/SwiftKuery/Insert.swift
@@ -76,7 +76,7 @@ public struct Insert: Query {
         }
         self.returnID = returnID
     }
-    
+
     /// Initialize an instance of Insert.
     ///
     /// - Parameter into: The table to insert rows.
@@ -84,7 +84,7 @@ public struct Insert: Query {
     public init(into table: Table, values: Any?..., returnID: Bool=false) {
         self.init(into: table, columns: nil, values: values, returnID: returnID)
     }
-    
+    #if swift(>=4.1.0)
     /// Initialize an instance of Insert.
     ///
     /// - Parameter into: The table to insert rows.
@@ -92,6 +92,15 @@ public struct Insert: Query {
     public init(into table: Table, values: [Any?], returnID: Bool=false) {
         self.init(into: table, columns: nil, values: values, returnID: returnID)
     }
+    #else
+    /// Initialize an instance of Insert.
+    ///
+    /// - Parameter into: The table to insert rows.
+    /// - Parameter values: An array of values (the row) to insert.
+    public init(into table: Table, optionalValues: [Any?], returnID: Bool=false) {
+        self.init(into: table, columns: nil, values: optionalValues, returnID: returnID)
+    }
+    #endif
 
     /// Initialize an instance of Insert.
     ///

--- a/Sources/SwiftKuery/Update.swift
+++ b/Sources/SwiftKuery/Update.swift
@@ -28,7 +28,7 @@ public struct Update: Query {
     /// A String with a clause to be appended to the end of the query.
     public private (set) var suffix: QuerySuffixProtocol?
 
-    private let valueTuples: [(column: Column, value: Any)]
+    private let valueTuples: [(column: Column, value: Any?)]
 
     /// An array of `AuxiliaryTable` which will be used in a query with a WITH clause.
     public private (set) var with: [AuxiliaryTable]?
@@ -40,7 +40,7 @@ public struct Update: Query {
     /// - Parameter table: The table to update.
     /// - Parameter set: An array of (column, value) tuples to set.
     /// - Parameter conditions: An optional where clause to apply.
-    public init(_ table: Table, set: [(Column, Any)], where conditions: QueryFilterProtocol?=nil) {
+    public init(_ table: Table, set: [(Column, Any?)], where conditions: QueryFilterProtocol?=nil) {
         self.table = table
         self.valueTuples = set
         self.whereClause = conditions

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -18,7 +18,10 @@ import Foundation
 
 struct Utils {
     
-    static func packType(_ item: Any) -> String {
+    static func packType(_ item: Any?) -> String {
+        guard let item = item else {
+            return "NULL"
+        }
         switch item {
         case let val as String:
             return "'\(val)'"
@@ -47,8 +50,6 @@ struct Utils {
             }
             return "'\(String(describing: value))'"
         default:
-            //let val = String(describing: item)
-            //return val == "nil" ? "NULL" : val
             return String(describing: item)
         }
     }

--- a/Sources/SwiftKuery/Utils.swift
+++ b/Sources/SwiftKuery/Utils.swift
@@ -29,7 +29,10 @@ struct Utils {
         }
     }
     
-    static func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
+    static func packType(_ item: Any?, queryBuilder: QueryBuilder) throws -> String {
+        guard let item = item else {
+            return "NULL"
+        }
         switch item {
         case let val as String:
             return "'\(val)'"
@@ -44,8 +47,9 @@ struct Utils {
             }
             return "'\(String(describing: value))'"
         default:
-            let val = String(describing: item)
-            return val == "nil" ? "NULL" : val
+            //let val = String(describing: item)
+            //return val == "nil" ? "NULL" : val
+            return String(describing: item)
         }
     }
         

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -244,8 +244,14 @@ class TestColumnBuilder : ColumnCreator {
         if column.isUnique {
             result += " UNIQUE"
         }
-        if let defaultValue = column.defaultValue {
-            result += " DEFAULT " + Utils.packType(defaultValue)
+        switch column.defaultValue {
+        case let defVal as UUID:
+            if defVal == Column.getDefaultVal() as! UUID {
+                break
+            }
+            fallthrough
+        default:
+            result += " DEFAULT " + Utils.packType(column.defaultValue)
         }
         if let checkExpression = column.checkExpression {
             result += checkExpression.contains(column.name) ? " CHECK (" + checkExpression.replacingOccurrences(of: column.name, with: "\"\(column.name)\"") + ")" : " CHECK (" + checkExpression + ")"

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -134,7 +134,11 @@ class TestInsert: XCTestCase {
         var query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
 
+        #if swift(>=4.1.0)
         i = Insert(into: t, values: [optionalString, optionalInt])
+        #else
+        i = Insert(into: t, optionalValues: [optionalString, optionalInt])
+        #endif
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -67,13 +67,6 @@ class TestInsert: XCTestCase {
         query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', 17) RETURNING *"
         XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
         
-        let optionalString: String? = nil
-        i = Insert(into: t, columns: [t.a, t.b], values: ["banana", optionalString as Any])
-            .suffix("RETURNING *")
-        kuery = connection.descriptionOf(query: i)
-        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES ('banana', NULL) RETURNING *"
-        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
-        
         i = Insert(into: t, rows: [["apple", 17], ["banana", -7], ["banana", 27]])
         kuery = connection.descriptionOf(query: i)
         query = "INSERT INTO \"tableInsert\" VALUES ('apple', 17), ('banana', -7), ('banana', 27)"

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -24,6 +24,7 @@ class TestInsert: XCTestCase {
         return [
             ("testInsert", testInsert),
             ("testInsertWith", testInsertWith),
+            ("testInsertNilValue", testInsertNilValue),
         ]
     }
         
@@ -127,5 +128,38 @@ class TestInsert: XCTestCase {
         } catch {
             XCTFail("Other than syntax error.")
         }
+    }
+
+    func testInsertNilValue() {
+        let t = MyTable()
+        let connection = createConnection()
+
+        let optionalString: String? = nil
+        let optionalInt: Int? = nil
+        var i = Insert(into: t, values: optionalString, optionalInt)
+        var kuery = connection.descriptionOf(query: i)
+        var query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, values: [optionalString, optionalInt])
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, valueTuples: (t.a, optionalString), (t.b, optionalInt))
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, columns: [t.a, t.b], values: [optionalString, optionalInt])
+            .suffix("RETURNING *")
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES (NULL, NULL) RETURNING *"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, rows: [[optionalString, optionalInt], [optionalString, optionalInt], [optionalString, optionalInt]])
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL), (NULL, NULL), (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -72,6 +72,11 @@ class TestSchema: XCTestCase {
         let b = Column("b")
     }
 
+    class Table6: Table {
+        let tableName = "table6"
+        let a = Column("a", String.self, defaultValue: nil)
+    }
+
     func testMultipleForeignKeys() {
         let connection = createConnection()
 
@@ -214,6 +219,11 @@ class TestSchema: XCTestCase {
         let connectionWithAutoIncrement = createConnection(createAutoIncrement: createAutoIncrement)
         createStmt = createTable(t1, connection: connectionWithAutoIncrement)
         expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        let nilValueTable = Table6()
+        createStmt = createTable(nilValueTable, connection: connection)
+        expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text DEFAULT NULL)"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
     

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -223,7 +223,7 @@ class TestSchema: XCTestCase {
 
         let nilValueTable = Table6()
         createStmt = createTable(nilValueTable, connection: connection)
-        expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text DEFAULT NULL)"
+        expectedCreateStmt = "CREATE TABLE \"table6\" (\"a\" text DEFAULT NULL)"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
     

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -23,6 +23,7 @@ class TestUpdate: XCTestCase {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
             ("testUpdateAndDeleteWith", testUpdateAndDeleteWith),
+            ("testUpdateNilValues", testUpdateNilValues),
         ]
     }
     
@@ -159,5 +160,37 @@ class TestUpdate: XCTestCase {
         } catch {
             XCTFail("Other than syntax error.")
         }
+    }
+
+    func testUpdateNilValues () {
+        let t = MyTable()
+        let connection = createConnection()
+
+        let optionalString: String? = nil
+        let optionalInt: Int? = nil
+        var u = Update(t, set: [(t.a, optionalString), (t.b, optionalInt)])
+            .where(t.a == "banana")
+        var kuery = connection.descriptionOf(query: u)
+        var query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL WHERE \"tableUpdate\".\"a\" = 'banana'"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString), (t.b, optionalInt)])
+            .where(t.a == "banana")
+            .suffix("RETURNING *")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL WHERE \"tableUpdate\".\"a\" = 'banana' RETURNING *"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString), (t.b, optionalInt)])
+            .suffix("RETURNING b,a")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL RETURNING b,a"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString), (t.b, optionalInt)])
+            .suffix("RETURNING tableUpdate.b")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL RETURNING tableUpdate.b"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }


### PR DESCRIPTION
This adds further support for the use of nil values.

Some signature changes have been made to prevent compiler warnings when trying to insert nil values into tables.

It also adds support for using nil as a default value for Columns in a table.