### PR TITLE
Ensure result set is released when error occurs during asRows

### DIFF
--- a/Sources/SwiftKuery/QueryResult.swift
+++ b/Sources/SwiftKuery/QueryResult.swift
@@ -92,8 +92,10 @@ public enum QueryResult {
             resultSet.getColumnTitles() { titles, error in
                 guard let columnTitles = titles else {
                     guard let error = error else {
+                        resultSet.done()
                         return onCompletion((nil, QueryError.noResult("Unable to retrieve Column titles")))
                     }
+                    resultSet.done()
                     return onCompletion((nil, QueryError.noResult(error.localizedDescription)))
                 }
                 return self.processRows(resultSet, titles: columnTitles, result: nil, onCompletion: onCompletion)

--- a/Sources/SwiftKuery/QueryResult.swift
+++ b/Sources/SwiftKuery/QueryResult.swift
@@ -120,10 +120,12 @@ public enum QueryResult {
                     resultSet.done()
                     return onCompletion((result, nil))
                 }
+                resultSet.done()
                 return onCompletion((nil, QueryError.noResult("Error fetching row: \(error.localizedDescription)")))
             }
             guard row.count == titles.count else {
                 // Column titles and value counts do not match
+                resultSet.done()
                 return onCompletion((nil, QueryError.noResult("Number of titles does not match number of values for row, unable to retrieve rows.")))
             }
             // myTitles will be updated with new column titles when a title collision occurs, for example if a JOIN results in columns from different table with the same name being included in the results. myTitles is then passed into the recursive call of processRows meaning we will only ever run collision handling when processing the first row of the results.


### PR DESCRIPTION
This PR updates `QueryResult.asRows` to ensure an embedded `resultSet` is closed when an error occurs.

The PR also updates `QueryResult.processRows` for the same reason.