### PR TITLE
Enhance support for nil values

### DIFF
--- a/Sources/SwiftKuery/Column.swift
+++ b/Sources/SwiftKuery/Column.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017, 2018
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -59,6 +59,10 @@ public class Column: Field, IndexColumn {
     
     /// The default value of the column.
     public let defaultValue: Any?
+
+    /// Property denoting whether default value is NULL
+    /// If set to true a `nil` value for the `defaultValue` property will be interpreted as `NULL`
+    public let nullDefaultValue: Bool
     
     /// An indication whether the column autoincrements.
     public let autoIncrement: Bool
@@ -94,10 +98,11 @@ public class Column: Field, IndexColumn {
      - Parameter notNull: An indication whether the column is not nullable. Defaults to false.
      - Parameter unique: An indication whether the column values have to be unique. Defaults to false.
      - Parameter defaultValue: The default value of the column. Defaults to nil.
+     - Parameter nullDefaultValue: Property denoting whether default value is NULL. Defaults to false.
      - Parameter check: The expression to check for values inserted into the column. Defaults to nil.
      - Parameter collate: The collation rule for the column. Defaults to nil.
      */
-    public init(_ name: String, _ type: SQLDataType.Type? = nil, length: Int? = nil, autoIncrement: Bool = false, primaryKey: Bool = false, notNull: Bool = false, unique: Bool = false, defaultValue: Any? = nil, check: String? = nil, collate: String? = nil) {
+    public init(_ name: String, _ type: SQLDataType.Type? = nil, length: Int? = nil, autoIncrement: Bool = false, primaryKey: Bool = false, notNull: Bool = false, unique: Bool = false, defaultValue: Any? = nil, nullDefaultValue: Bool = false, check: String? = nil, collate: String? = nil) {
         self.name = name
         self.type = type
         self.length = length
@@ -106,6 +111,7 @@ public class Column: Field, IndexColumn {
         self.isNotNullable = notNull
         self.isUnique = unique
         self.defaultValue = defaultValue
+        self.nullDefaultValue = nullDefaultValue
         self.checkExpression = check
         self.collate = collate
     }
@@ -210,7 +216,7 @@ public class Column: Field, IndexColumn {
     public func `as`(_ newName: String) -> Column {
         let new = Column(name, type, length: length, autoIncrement: autoIncrement,
                          primaryKey: isPrimaryKey, notNull: isNotNullable, unique: isUnique,
-                         defaultValue: defaultValue, check: checkExpression, collate: collate)
+                         defaultValue: defaultValue, nullDefaultValue: nullDefaultValue, check: checkExpression, collate: collate)
         new.alias = newName
         new._table = table
         return new

--- a/Sources/SwiftKuery/ColumnCreator.swift
+++ b/Sources/SwiftKuery/ColumnCreator.swift
@@ -28,14 +28,14 @@ public protocol ColumnCreator {
     func buildColumn(for column: Column, using queryBuilder: QueryBuilder) -> String?
 
     /// Build an appropriate representation of a passed value for the database
-    /// A default implemetation is provided that can be overriden should a
+    /// A default implementation is provided that can be overriden should a
     /// plugin require non-common behaviour
     ///
     /// - Parameter item: The value to convert
     /// - Returns: A string representing the value that can be passed into the database
     func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String
 
-    /// Get the dafault value for a column
+    /// Get the default value for a column
     ///
     /// - Parameter for: The Column to get the default value for
     /// - Parameter queryBuilder: The plugin specific queryBuilder

--- a/Sources/SwiftKuery/ColumnCreator.swift
+++ b/Sources/SwiftKuery/ColumnCreator.swift
@@ -74,8 +74,7 @@ public extension ColumnCreator {
             }
             return "'\(String(describing: value))'"
         default:
-            let val = String(describing: item)
-            return val == "nil" ? "NULL" : val
+            return String(describing: item)
         }
     }
 }

--- a/Sources/SwiftKuery/ColumnCreator.swift
+++ b/Sources/SwiftKuery/ColumnCreator.swift
@@ -52,7 +52,7 @@ public extension ColumnCreator {
             }
             return nil
         }
-        do{
+        do {
             return try packType(defaultValue, queryBuilder: queryBuilder)
         } catch {
             return nil

--- a/Tests/SwiftKueryTests/CommonUtils.swift
+++ b/Tests/SwiftKueryTests/CommonUtils.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016, 2017, 2018, 2019
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,8 +244,8 @@ class TestColumnBuilder : ColumnCreator {
         if column.isUnique {
             result += " UNIQUE"
         }
-        if let defaultValue = column.defaultValue {
-            result += " DEFAULT " + Utils.packType(defaultValue)
+        if let defaultValue = getDefaultValue(for: column, queryBuilder: queryBuilder) {
+            result += " DEFAULT " + defaultValue
         }
         if let checkExpression = column.checkExpression {
             result += checkExpression.contains(column.name) ? " CHECK (" + checkExpression.replacingOccurrences(of: column.name, with: "\"\(column.name)\"") + ")" : " CHECK (" + checkExpression + ")"

--- a/Tests/SwiftKueryTests/TestInsert.swift
+++ b/Tests/SwiftKueryTests/TestInsert.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ class TestInsert: XCTestCase {
         return [
             ("testInsert", testInsert),
             ("testInsertWith", testInsertWith),
+            ("testInsertNilValue", testInsertNilValue),
         ]
     }
         
@@ -127,5 +128,38 @@ class TestInsert: XCTestCase {
         } catch {
             XCTFail("Other than syntax error.")
         }
+    }
+
+    func testInsertNilValue() {
+        let t = MyTable()
+        let connection = createConnection()
+
+        let optionalString: String? = nil
+        let optionalInt: Int? = nil
+        var i = Insert(into: t, values: optionalString as Any, optionalInt as Any)
+        var kuery = connection.descriptionOf(query: i)
+        var query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, values: [optionalString as Any, optionalInt as Any])
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, valueTuples: (t.a, optionalString as Any), (t.b, optionalInt as Any))
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, columns: [t.a, t.b], values: [optionalString as Any, optionalInt as Any])
+            .suffix("RETURNING *")
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" (\"a\", \"b\") VALUES (NULL, NULL) RETURNING *"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        i = Insert(into: t, rows: [[optionalString as Any, optionalInt as Any], [optionalString as Any, optionalInt as Any], [optionalString as Any, optionalInt as Any]])
+        kuery = connection.descriptionOf(query: i)
+        query = "INSERT INTO \"tableInsert\" VALUES (NULL, NULL), (NULL, NULL), (NULL, NULL)"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }

--- a/Tests/SwiftKueryTests/TestSchema.swift
+++ b/Tests/SwiftKueryTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -70,6 +70,11 @@ class TestSchema: XCTestCase {
         let tableName = "table5"
         let a = Column("a", Char.self)
         let b = Column("b")
+    }
+
+    class Table6: Table {
+        let tableName = "table6"
+        let a = Column("a", String.self, defaultValue: nil, nullDefaultValue: true)
     }
 
     func testMultipleForeignKeys() {
@@ -214,6 +219,11 @@ class TestSchema: XCTestCase {
         let connectionWithAutoIncrement = createConnection(createAutoIncrement: createAutoIncrement)
         createStmt = createTable(t1, connection: connectionWithAutoIncrement)
         expectedCreateStmt = "CREATE TABLE \"table1\" (\"a\" text PRIMARY KEY DEFAULT 'qiwi' COLLATE \"en_US\", \"b\" integer AUTO_INCREMENT, \"c\" double DEFAULT 4.95 CHECK (\"c\" > 0))"
+        XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
+
+        let nilValueTable = Table6()
+        createStmt = createTable(nilValueTable, connection: connection)
+        expectedCreateStmt = "CREATE TABLE \"table6\" (\"a\" text DEFAULT NULL)"
         XCTAssertEqual(createStmt, expectedCreateStmt, "\nError in table creation: \n\(createStmt) \ninstead of \n\(expectedCreateStmt)")
     }
     

--- a/Tests/SwiftKueryTests/TestUpdate.swift
+++ b/Tests/SwiftKueryTests/TestUpdate.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ class TestUpdate: XCTestCase {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
             ("testUpdateAndDeleteWith", testUpdateAndDeleteWith),
+            ("testUpdateNilValues", testUpdateNilValues),
         ]
     }
     
@@ -159,5 +160,37 @@ class TestUpdate: XCTestCase {
         } catch {
             XCTFail("Other than syntax error.")
         }
+    }
+
+    func testUpdateNilValues () {
+        let t = MyTable()
+        let connection = createConnection()
+
+        let optionalString: String? = nil
+        let optionalInt: Int? = nil
+        var u = Update(t, set: [(t.a, optionalString as Any), (t.b, optionalInt as Any)])
+            .where(t.a == "banana")
+        var kuery = connection.descriptionOf(query: u)
+        var query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL WHERE \"tableUpdate\".\"a\" = 'banana'"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString as Any), (t.b, optionalInt as Any)])
+            .where(t.a == "banana")
+            .suffix("RETURNING *")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL WHERE \"tableUpdate\".\"a\" = 'banana' RETURNING *"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString as Any), (t.b, optionalInt as Any)])
+            .suffix("RETURNING b,a")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL RETURNING b,a"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        u = Update(t, set: [(t.a, optionalString as Any), (t.b, optionalInt as Any)])
+            .suffix("RETURNING tableUpdate.b")
+        kuery = connection.descriptionOf(query: u)
+        query = "UPDATE \"tableUpdate\" SET \"a\" = NULL, \"b\" = NULL RETURNING tableUpdate.b"
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }


### PR DESCRIPTION
This PR adds support for using nil to represent NULL for default column values.

The PR also adds test for inset, update and table creation when using nil values.