### PR TITLE
SQL COUNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,14 @@ let query = Select(from: t1)
 
 &nbsp;
 
+__SELECT COUNT(t1.a) FROM t1;__
+
+```swift
+let query = Select.count(t1.a, from: t1)
+```
+
+&nbsp;
+
 #### Queries with parameters:                         
 **Note**: Named parameters are supported for all databases, even for those that do not support named parameters (e.g. PostgreSQL).
 

--- a/Tests/SwiftKueryTests/TestSelect.swift
+++ b/Tests/SwiftKueryTests/TestSelect.swift
@@ -23,6 +23,7 @@ class TestSelect: XCTestCase {
         return [
             ("testSelect", testSelect),
             ("testSelectWith", testSelectWith),
+            ("testSelectCount", testSelectCount),
         ]
     }
     
@@ -211,5 +212,25 @@ class TestSelect: XCTestCase {
         } catch {
             XCTFail("Other than syntax error.")
         }
+    }
+
+    func testSelectCount() {
+        let t = MyTable()
+        let connection = createConnection()
+        
+        // var s = Select(from: t)
+        // var kuery = connection.descriptionOf(query: s)
+        // var query = "SELECT * FROM \"tableSelect\""
+        // XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+        
+        var s = Select.count(from: t)
+        var kuery = connection.descriptionOf(query: s)
+        var query = "SELECT COUNT(id) FROM \"tableSelect\""
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
+
+        s = Select.count(t.a, from: t)
+        kuery = connection.descriptionOf(query: s)
+        query = "SELECT COUNT(\"tableSelect\".\"a\") FROM \"tableSelect\""
+        XCTAssertEqual(kuery, query, "\nError in query construction: \n\(kuery) \ninstead of \n\(query)")
     }
 }


### PR DESCRIPTION
Add the COUNT function into the SELECT query.
If no fields are provided, it uses `id`.