### PR TITLE
If no data is found return empty set

### DIFF
--- a/Sources/SwiftKuery/QueryResult.swift
+++ b/Sources/SwiftKuery/QueryResult.swift
@@ -118,7 +118,7 @@ public enum QueryResult {
                 guard let error = error else {
                     // We have run out of rows so need to return the results and explicitly close the result set allowing the release of the underlying connection.
                     resultSet.done()
-                    return onCompletion((result, nil))
+                    return onCompletion((result ?? [], nil))
                 }
                 resultSet.done()
                 return onCompletion((nil, QueryError.noResult("Error fetching row: \(error.localizedDescription)")))


### PR DESCRIPTION
If we query the db and get an empty set we should return an empty set instead of nil.